### PR TITLE
Use string representation from GeometryType in RecoverGeometryColumn.

### DIFF
--- a/versioning_base.py
+++ b/versioning_base.py
@@ -572,8 +572,8 @@ def update(sqlite_filename, pg_conn_info):
                 "'"+table+"_conflicts', 'GEOMETRY', "
                 "(SELECT srid FROM geometry_columns "
                 "WHERE f_table_name='"+table+"'), "
-                "(SELECT geometry_type FROM geometry_columns "
-                "WHERE f_table_name='"+table+"'), 'XY')")
+                "(SELECT GeometryType(geometry) FROM "+table+" LIMIT 1), "
+                "'XY')")
 
             scur.execute("CREATE UNIQUE INDEX IF NOT EXISTS "
                 +table+"_conflicts_idx ON "+table+"_conflicts(OGC_FID)")


### PR DESCRIPTION
Since Spatialite v4.0.0 the geometry_type is saved as an integer value
in geometry_columns [1]. However, the RecoverGeometryColumn function
still expects a string representation.

Instead of getting the geometry_type from the geometry_columns, get it
directly from the geometry in the table using the GeometryType function,
which does return a string.

The geometry column name will always be 'geometry' as this is the default
used by OGR [2], and the table will always contain at least 1 record, since
otherwise there cannot be any conflict.

[1]: https://www.gaia-gis.it/fossil/libspatialite/wiki?name=switching-to-4.0