### PR TITLE
General commit and update modifications

### DIFF
--- a/versioning.py
+++ b/versioning.py
@@ -121,7 +121,7 @@ class Versioning:
         self.current_group_idx = -1
         name = ''
         self.current_layers = []
-        self.info.setText('No group selected')
+        self.info.setText('Versioning : no group selected')
         for act in self.actions:
             if act.text() in ['checkout',
                               'update',
@@ -149,7 +149,7 @@ class Versioning:
         group_idx = [i for i, x in
                 enumerate(self.iface.legendInterface().groups()) if x == name]
         if len(group_idx) != 1:
-            self.info.setText("More than one group with this name")
+            self.info.setText("Versioning : more than one group with this name")
             self.current_layers = []
             return
         [self.current_group_idx] = group_idx
@@ -171,7 +171,7 @@ class Versioning:
             if previous_conn:
                 if (uri.database(), uri.schema()) != previous_conn:
                     self.current_layers = []
-                    self.info.setText("Layers don't share db and schema")
+                    self.info.setText("Versioning : layers don't share db and schema")
                     return
             else:
                 previous_conn = (uri.database(), uri.schema())
@@ -181,7 +181,7 @@ class Versioning:
 
         if not len(previous_conn[0]):
             self.current_layers = []
-            self.info.setText("Not versionable")
+            self.info.setText("Versioning : not versionable")
             return
 
         layer = QgsMapLayerRegistry.instance().mapLayer(
@@ -194,9 +194,9 @@ class Versioning:
                 rev = versioning_base.revision( uri.database() )
             except:
                 self.current_layers = []
-                self.info.setText("The selected group is not a working copy")
+                self.info.setText("Versioning : the selected group is not a working copy")
                 return
-            self.info.setText( uri.database() +' rev='+str(rev))
+            self.info.setText( uri.database() +' <b>working rev</b>='+str(rev))
             selection_type = 'working copy'
         if layer.providerType() == "postgres":
             mtch = re.match(r'(.+)_([^_]+)_rev_(head|\d+)', uri.schema())
@@ -215,9 +215,9 @@ class Versioning:
                                                        uri.schema() )
                     selection_type = 'working copy'
                     self.info.setText( uri.database()+' '+uri.schema()
-                            +' rev='+str(rev) )
+                            +' <b>working rev</b>='+str(rev) )
                 except:
-                    self.info.setText('Unversioned schema')
+                    self.info.setText('Versioning : unversioned schema')
                     selection_type = 'unversioned'
 
 
@@ -243,7 +243,7 @@ class Versioning:
     def initGui(self):
         """Called once QGIS gui is loaded, before project is loaded"""
 
-        self.info.setText('No group selected')
+        self.info.setText('Versioning : no group selected')
         self.actions.append( self.iface.addToolBarWidget( self.info ) )
 
         # we could have a checkbox to either replace/add layers
@@ -498,19 +498,45 @@ class Versioning:
                 self.current_layers[0] )
         uri = QgsDataSourceURI(layer.source())
 
+        late_by = 0
+
         if layer.providerType() == "spatialite":
-            versioning_base.update( uri.database(), self.pg_conn_info() )
-            rev = versioning_base.revision( uri.database() )
+            late_by = versioning_base.late(
+                    uri.database(), self.pg_conn_info() )
         else: # postgres
-            versioning_base.pg_update( uri.connectionInfo(), uri.schema() )
-            rev = versioning_base.pg_revision(
-                    uri.connectionInfo(), uri.schema() )
+            late_by = versioning_base.pg_late(
+                    self.pg_conn_info(), uri.schema() )
+        if late_by:
+            if layer.providerType() == "spatialite":
+                versioning_base.update( uri.database(), self.pg_conn_info() )
+                rev = versioning_base.revision( uri.database() )
+            else: # postgres
+                versioning_base.pg_update( uri.connectionInfo(), uri.schema() )
+                rev = versioning_base.pg_revision(
+                        uri.connectionInfo(), uri.schema() )
 
-        if not self.unresolved_conflicts():
-            QMessageBox.information( self.iface.mainWindow(), "Notice",
-                    "You are up to date with revision "+str(rev-1)+".")
+            # Force refresh of map
+            if self.iface.mapCanvas().isCachingEnabled():
+                self.iface.mapCanvas().clearCache()
+                self.iface.mapCanvas().refresh()
+            else:
+                self.iface.mapCanvas().refresh()
 
+            # Force refresh of rev number in menu text
+            self.info.setText( uri.database() +' <b>working rev</b>='+str(rev))
 
+            if not self.unresolved_conflicts():
+                QMessageBox.warning( self.iface.mainWindow(), "Warning",
+                "Working copy was late by "+str(late_by)+" revision(s).\n"
+                "Now up to date with remote revision "+str(rev-1)+".")
+        else:
+            if layer.providerType() == "spatialite":
+                rev = versioning_base.revision( uri.database() )
+            else: # postgres
+                rev = versioning_base.pg_revision(
+                        uri.connectionInfo(), uri.schema() )
+            QMessageBox.information( self.iface.mainWindow(), "Info","Working "
+            "copy already up to date with remote revision "+str(rev-1)+".")
 
     def historize(self):
         """version database"""
@@ -559,8 +585,9 @@ class Versioning:
         """create working copy from versioned database layers"""
         # for each connection, we need the list of tables
         tables_for_conninfo = []
-        # for each layer, we need the list of user selected features to be checked out
-        # if a given layer has no user selected features, then all features will be checked out
+        # for each layer, we need the list of user selected features to be
+        # checked out; if a given layer has no user selected features, then all
+        # features will be checked out
         user_selected_features = []
         uri = None
         conn_info = ''
@@ -568,9 +595,11 @@ class Versioning:
             layer = QgsMapLayerRegistry.instance().mapLayer( layer_id )
             layer_selected_features = layer.selectedFeatures()
             if layer_selected_features:
-                QMessageBox.warning(None,"Warning","You will be checking out the subset of \
-"+str(len(layer_selected_features))+" features you selected in layer \""+layer.name()+"\".\n\n\
-If you want the whole data set for that layer, abort checkout in the pop up window asking for a filename, unselect features and start over.")
+                QMessageBox.warning(None,"Warning","You will be checking out "
+                "the subset of "+str(len(layer_selected_features))+" features "
+                "you selected in layer \""+layer.name()+"\".\n\nIf you want "
+                "the whole data set for that layer, abort checkout in the pop "
+                "up asking for a filename, unselect features and start over.")
                 user_selected_features.append(layer_selected_features)
             else:
                 user_selected_features.append([])
@@ -612,7 +641,6 @@ If you want the whole data set for that layer, abort checkout in the pop up wind
                     +geom,display_name, 'spatialite')
             self.iface.legendInterface().moveLayer( new_layer, grp_idx)
         self.iface.legendInterface().setGroupExpanded( grp_idx, True )
-
 
     def checkout_pg(self):
         """create postgres working copy (schema) from versioned
@@ -671,7 +699,6 @@ If you want the whole data set for that layer, abort checkout in the pop up wind
             new_layer = self.iface.addVectorLayer(src, display_name, 'postgres')
             self.iface.legendInterface().moveLayer( new_layer, grp_idx)
 
-
     def commit(self):
         """merge modifications into database"""
         print "commit"
@@ -721,8 +748,15 @@ If you want the whole data set for that layer, abort checkout in the pop up wind
                     uri.connectionInfo(), uri.schema())
 
         if nb_of_updated_layer:
-            #self.iface.messageBar().pushMessage("Info", "You have successfully committed revision "+str( rev ), duration=10)
-            QMessageBox.information(self.iface.mainWindow(), "Info", "You have successfully committed revision "+str( rev ) )
+            #self.iface.messageBar().pushMessage("Info",
+            #"You have successfully committed revision "+str( rev ), duration=10)
+            QMessageBox.information(self.iface.mainWindow(), "Info",
+            "You have successfully committed remote revision "+str( rev-1 ) )
+
+            # Force refresh of rev number in menu text
+            self.info.setText( uri.database() +' <b>working rev</b>='+str(rev))
         else:
-            #self.iface.messageBar().pushMessage("Info", "There was no modification to commit", duration=10)
-            QMessageBox.information(self.iface.mainWindow(), "Info", "There was no modification to commit")
+            #self.iface.messageBar().pushMessage("Info",
+            #"There was no modification to commit", duration=10)
+            QMessageBox.information(self.iface.mainWindow(), "Info",
+            "There was no modification to commit")


### PR DESCRIPTION
In relation to GISeHealth#19,  GISeHealth#20 and GISeHealth#2, here is a series of edits to versioning.py. 

- Added force refresh of the canvas after update, if any

Rationale : the user should not have to pan or zoom in the map to see changes to geometries that were updated into the working copy (https://github.com/GISeHealth/qgis-versioning/issues/19)

- Modified the update process : if the current revision of the working copy is not late (late_by = 0), no update is performed and an info message "Working copy already up to date with remote revision" pops; else, a warning message[1] tells the user the working copy was late by "N" commits and it was updated.

Rationale : updating forces changes into the working copy.  Even though unmodified features in the working copy can be logically thought of as being readily overridable (I'm personnally not so sure as it may well be that the current editor wants features the way they are in his working copy), I feel it is important to let the user know if something was really written in the working copy.  If the working copy is up to date with the versioned database, then we don't run [pg_]update and let the user know there was no change.  If there were changes, the plugin needs a way to notify the user, as those changes may not be noticeable on the map (e.g. attribute changes).  

- Fixed "rev= " type strings in menu; after commit or update, the rev number is now readily incremented in the QGIS group; the user no longer has to click some other element in the legend for the number to be incremented

- Changed vocabulary relative to revisions; remote revisions pertain to the central DB and local revs to working copies.

Rationale : revision numbers as presented to the user in the normal operation of the plugin were misleading.  First, there was no distinction between revisions in the working copy and remote revisions.  Second, revision numbers as shown in the pop ups and on the plugin menu [2] sometimes differed and the difference was hard to understand.  The change in vocabulary now makes it clearer to the user what is their working revision and what is the remote revision.  It makes sense given that context that the local revision is +1 with respect to the remote revision.

- Added the prefix "Versioning : " to setText messages appearing in the leftmost section of the plugin menu.

Rationale : Messages that show up alone in the plugin menu, that is without any of the plugin icons (like "No group selected") are a bit odd for users since nothing tells them that this string comes from the plugin.  "Versioning : no group selected" makes the association clearer.  If there were a way to identify the plugin menu graphically so that strings/messages showing up there could be readily associated with the plugin, then we could drop the prefix.  I have a "docs" branch that adds a "help" button in the plugin menu so when that gets merged then there will be at least one icon always showing up in the plugin menu.  When the user clicks on a versioned group then the plugin menu populates with many icons and therefore messages are easier to associate as emanating from the plugin.  For that reason messages involving a filename or database name were not preprended with the prefix.

- Pep 8 : there are still lines of code > 80 chars; I fixed mine (one of my strings were keeping my editor from folding the code correctly)

- Got rid of extra spaces between defs so that code folding in editors looks cleaner

[1] Could be an info message but I think warning is warranted here since changes were pushed in the working copy.  The info box (information messages in general ?) could be changed to a message bar to avoid user clicks.

[2] I took the liberty to make the revision string bold in the plugin menu; it is debatable, but the objective here is to make the leftmost string in the plugin menu clearer; it is now a concatenation of several items (db name, db schema, filename for spatialite, revision number) and, short of having a way to present the string in a cleaner manner I thought using some formatting would help