### PR TITLE
New checkout (commit) icons

### DIFF
--- a/checkout.svg
+++ b/checkout.svg
@@ -7,7 +7,6 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="24"
@@ -15,7 +14,7 @@
    id="svg5692"
    version="1.1"
    inkscape:version="0.48.4 r9939"
-   sodipodi:docname="checkout.svg"
+   sodipodi:docname="checkout_main.svg"
    inkscape:export-filename="/home/denis/Desktop/oracle.png"
    inkscape:export-xdpi="67.5"
    inkscape:export-ydpi="67.5">
@@ -120,424 +119,6 @@
        inkscape:vp_y="0 : 1000 : 0"
        inkscape:vp_x="0 : 278.36438 : 1"
        sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 278.36438 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="540.08875 : 278.36438 : 1"
-       inkscape:persp3d-origin="270.04437 : 185.57625 : 1"
-       id="perspective2491-7" />
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 278.36438 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="540.08875 : 278.36438 : 1"
-       inkscape:persp3d-origin="270.04437 : 185.57625 : 1"
-       id="perspective2850-3" />
-    <filter
-       color-interpolation-filters="sRGB"
-       id="filter4128-5"
-       inkscape:label="Drop shadow"
-       width="1.5"
-       height="1.5"
-       x="-0.25"
-       y="-0.25">
-      <feGaussianBlur
-         id="feGaussianBlur4130-3"
-         in="SourceAlpha"
-         stdDeviation="2.000000"
-         result="blur" />
-      <feColorMatrix
-         id="feColorMatrix4132-0"
-         result="bluralpha"
-         type="matrix"
-         values="1 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 0.351000 0 " />
-      <feOffset
-         id="feOffset4134-1"
-         in="bluralpha"
-         dx="7.500000"
-         dy="7.500000"
-         result="offsetBlur" />
-      <feMerge
-         id="feMerge4136-0">
-        <feMergeNode
-           id="feMergeNode4138-7"
-           in="offsetBlur" />
-        <feMergeNode
-           id="feMergeNode4140-7"
-           in="SourceGraphic" />
-      </feMerge>
-    </filter>
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       id="perspective4762-2" />
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       id="perspective9811-1" />
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       id="perspective8710-5" />
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       id="perspective7871-7" />
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       id="perspective3600-7" />
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       id="perspective3496-6" />
-    <inkscape:perspective
-       id="perspective3486-0"
-       inkscape:persp3d-origin="16 : 10.666667 : 1"
-       inkscape:vp_z="32 : 16 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 16 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <linearGradient
-       id="linearGradient3906-7-3"
-       inkscape:collect="always">
-      <stop
-         id="stop3908-6-3"
-         offset="0"
-         style="stop-color:#2c89a0;stop-opacity:1;" />
-      <stop
-         id="stop3910-2-1"
-         offset="1"
-         style="stop-color:#2c89a0;stop-opacity:0;" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3906-7-3"
-       id="linearGradient3969-7"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(0.62114454,11.887986)"
-       x1="8.3854542"
-       y1="10.024242"
-       x2="20.941452"
-       y2="9.7580376" />
-    <linearGradient
-       id="linearGradient3906-7-5"
-       inkscape:collect="always">
-      <stop
-         id="stop3908-6-6"
-         offset="0"
-         style="stop-color:#2c89a0;stop-opacity:1;" />
-      <stop
-         id="stop3910-2-4"
-         offset="1"
-         style="stop-color:#2c89a0;stop-opacity:0;" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3906-7-5"
-       id="linearGradient3969-5"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(0.62114454,11.887986)"
-       x1="8.3854542"
-       y1="10.024242"
-       x2="20.941452"
-       y2="9.7580376" />
-    <linearGradient
-       id="linearGradient3906-7"
-       inkscape:collect="always">
-      <stop
-         id="stop3908-6"
-         offset="0"
-         style="stop-color:#2c89a0;stop-opacity:1;" />
-      <stop
-         id="stop3910-2"
-         offset="1"
-         style="stop-color:#2c89a0;stop-opacity:0;" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="translate(0.53240981,11.904339)"
-       gradientUnits="userSpaceOnUse"
-       y2="9.7580376"
-       x2="20.941452"
-       y1="10.024242"
-       x1="8.3854542"
-       id="linearGradient3916-6"
-       xlink:href="#linearGradient3906-7"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientUnits="userSpaceOnUse"
-       y2="13.18094"
-       x2="22.520084"
-       y1="11.470613"
-       x1="6.6438971"
-       id="linearGradient3952"
-       xlink:href="#linearGradient3906"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(0.53240981,3.9043386)"
-       gradientUnits="userSpaceOnUse"
-       y2="17.758038"
-       x2="20.941452"
-       y1="18.024242"
-       x1="8.3854542"
-       id="linearGradient3914"
-       xlink:href="#linearGradient3906"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(0.53240981,3.9043386)"
-       gradientUnits="userSpaceOnUse"
-       y2="17.758038"
-       x2="20.941452"
-       y1="18.024242"
-       x1="8.3854542"
-       id="linearGradient3912"
-       xlink:href="#linearGradient3906"
-       inkscape:collect="always" />
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 16 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="32 : 16 : 1"
-       inkscape:persp3d-origin="16 : 10.666667 : 1"
-       id="perspective3486-0-3" />
-    <inkscape:perspective
-       id="perspective3496-6-2"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective3600-7-2"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective7871-7-6"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective8710-5-5"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective9811-1-9"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective4762-2-8"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <filter
-       y="-0.25"
-       x="-0.25"
-       height="1.5"
-       width="1.5"
-       inkscape:label="Drop shadow"
-       id="filter4128-5-6"
-       color-interpolation-filters="sRGB">
-      <feGaussianBlur
-         result="blur"
-         stdDeviation="2.000000"
-         in="SourceAlpha"
-         id="feGaussianBlur4130-3-6" />
-      <feColorMatrix
-         values="1 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 0.351000 0 "
-         type="matrix"
-         result="bluralpha"
-         id="feColorMatrix4132-0-9" />
-      <feOffset
-         result="offsetBlur"
-         dy="7.500000"
-         dx="7.500000"
-         in="bluralpha"
-         id="feOffset4134-1-7" />
-      <feMerge
-         id="feMerge4136-0-6">
-        <feMergeNode
-           in="offsetBlur"
-           id="feMergeNode4138-7-5" />
-        <feMergeNode
-           in="SourceGraphic"
-           id="feMergeNode4140-7-9" />
-      </feMerge>
-    </filter>
-    <inkscape:perspective
-       id="perspective2850-3-6"
-       inkscape:persp3d-origin="270.04437 : 185.57625 : 1"
-       inkscape:vp_z="540.08875 : 278.36438 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 278.36438 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective2491-7-1"
-       inkscape:persp3d-origin="270.04437 : 185.57625 : 1"
-       inkscape:vp_z="540.08875 : 278.36438 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 278.36438 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 278.36438 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="540.08875 : 278.36438 : 1"
-       inkscape:persp3d-origin="270.04437 : 185.57625 : 1"
-       id="perspective2491-2" />
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 278.36438 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="540.08875 : 278.36438 : 1"
-       inkscape:persp3d-origin="270.04437 : 185.57625 : 1"
-       id="perspective2850-9" />
-    <filter
-       color-interpolation-filters="sRGB"
-       id="filter4128-1"
-       inkscape:label="Drop shadow"
-       width="1.5"
-       height="1.5"
-       x="-0.25"
-       y="-0.25">
-      <feGaussianBlur
-         id="feGaussianBlur4130-4"
-         in="SourceAlpha"
-         stdDeviation="2.000000"
-         result="blur" />
-      <feColorMatrix
-         id="feColorMatrix4132-3"
-         result="bluralpha"
-         type="matrix"
-         values="1 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 0.351000 0 " />
-      <feOffset
-         id="feOffset4134-6"
-         in="bluralpha"
-         dx="7.500000"
-         dy="7.500000"
-         result="offsetBlur" />
-      <feMerge
-         id="feMerge4136-1">
-        <feMergeNode
-           id="feMergeNode4138-1"
-           in="offsetBlur" />
-        <feMergeNode
-           id="feMergeNode4140-3"
-           in="SourceGraphic" />
-      </feMerge>
-    </filter>
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       id="perspective4762-27" />
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       id="perspective9811-2" />
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       id="perspective8710-50" />
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       id="perspective7871-5" />
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       id="perspective3600-75" />
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       id="perspective3496-1" />
-    <inkscape:perspective
-       id="perspective3486-7"
-       inkscape:persp3d-origin="16 : 10.666667 : 1"
-       inkscape:vp_z="32 : 16 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 16 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <linearGradient
-       id="linearGradient3906"
-       inkscape:collect="always">
-      <stop
-         id="stop3908"
-         offset="0"
-         style="stop-color:#2c89a0;stop-opacity:1;" />
-      <stop
-         id="stop3910"
-         offset="1"
-         style="stop-color:#2c89a0;stop-opacity:0;" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3906-7"
-       id="linearGradient3126"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(0.62114454,11.887986)"
-       x1="8.3854542"
-       y1="10.024242"
-       x2="20.941452"
-       y2="9.7580376" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3906-7-5"
-       id="linearGradient3128"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(0.62114454,11.887986)"
-       x1="8.3854542"
-       y1="10.024242"
-       x2="20.941452"
-       y2="9.7580376" />
   </defs>
   <sodipodi:namedview
      id="base"
@@ -546,20 +127,20 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="15.9375"
-     inkscape:cx="12.277178"
-     inkscape:cy="6.388619"
+     inkscape:zoom="22.539029"
+     inkscape:cx="5.9328623"
+     inkscape:cy="11.976829"
      inkscape:current-layer="layer2"
      showgrid="true"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
      borderlayer="false"
-     inkscape:window-width="1600"
-     inkscape:window-height="850"
+     inkscape:window-width="1280"
+     inkscape:window-height="696"
      inkscape:window-x="0"
-     inkscape:window-y="28"
+     inkscape:window-y="24"
      inkscape:window-maximized="1"
-     inkscape:snap-global="false"
+     inkscape:snap-global="true"
      showguides="true"
      inkscape:guide-bbox="true"
      inkscape:snap-object-midpoints="false"
@@ -642,47 +223,163 @@
        style="fill-rule:nonzero;stroke:#415a75;stroke-width:0.13082823;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
        d="" />
     <g
-       style="fill:none;stroke:#415a75;stroke-miterlimit:4;stroke-opacity:1;filter:url(#filter4128-5)"
-       id="orginal-61"
-       transform="matrix(0.05336966,0,0,0.05336966,-59.982974,5.7601648)" />
+       id="g3033"
+       transform="matrix(1.0532888,0,0,1.0532733,-0.87519706,-0.65308821)">
+      <path
+         style="fill:#6d97c4;fill-opacity:1;fill-rule:evenodd;stroke:#2b3b4d;stroke-width:0.55595154;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         sodipodi:nodetypes="cccccccccccc"
+         id="path832"
+         d="m 2.4967632,25.719803 c 0.5533036,-1.810469 1.3717001,-2.751016 2.3395996,-4.351341 1.2168338,-1.79079 1.9206733,-3.443645 3.5629555,-5.09386 1.7474887,-2.065056 4.4113197,-5.019948 7.1950337,-5.456824 2.822517,-0.188019 6.102135,-2.4622698 6.606974,-2.317778 -0.896315,1.750794 0.168406,3.712601 -0.407798,5.5979 -0.419848,1.200397 -5.930514,4.338158 -6.693464,4.693904 -0.919715,0.564033 -4.194041,4.016912 -5.092867,4.645799 -1.001922,0.88102 -0.8009958,1.996952 -2.3594326,1.949237 -0.059987,-0.01469 -3.2629169,0.393902 -4.5121762,0.566578 -0.4780231,1.285744 3.5527663,-0.08636 1.4613101,0.855639 -0.9790157,0.44137 -2.6770392,0.448133 -2.1001351,-1.089254 z"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:#ffffff;fill-rule:evenodd;stroke-width:1pt"
+         sodipodi:nodetypes="cccc"
+         id="path834"
+         d="m 4.6631855,23.884593 c 0.3600559,0.02435 3.4669066,0.21707 5.1486433,-0.656932 -2.7850945,0.356788 -4.4579005,0.129005 -4.7714483,0.174446 -0.073511,0.09414 -0.2348885,0.352685 -0.377195,0.482486 z"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:#ffffff;fill-rule:evenodd;stroke-width:1pt"
+         sodipodi:nodetypes="cccc"
+         id="path835"
+         d="m 3.7492361,25.408274 c 0.3600561,0.02435 3.7481361,-0.330276 5.4298686,-1.204305 -2.7850936,0.356788 -4.6888301,0.577032 -5.0983927,0.646825 -0.020928,0.146729 -0.1891692,0.42768 -0.3314759,0.55748 z"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:#ffffff;fill-rule:evenodd;stroke-width:1pt"
+         sodipodi:nodetypes="cccc"
+         id="path836"
+         d="m 5.55638,22.703325 c 0.3600549,0.02435 4.0533158,0.280421 5.735053,-0.593579 -2.7850947,0.356788 -4.9745886,0.03936 -5.2881355,0.0848 -0.073508,0.09414 -0.3046111,0.378978 -0.4469177,0.508779 z"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:#ffffff;fill-rule:evenodd;stroke-width:1pt"
+         sodipodi:nodetypes="cccc"
+         id="path837"
+         d="m 6.6902524,21.347802 c 0.3600558,0.02435 4.1104766,0.400237 5.7922136,-0.473765 -2.7850944,0.356787 -4.979164,-0.10675 -5.292712,-0.06131 -0.073508,0.09414 -0.3571954,0.405269 -0.4995021,0.535071 z"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:#ffffff;fill-rule:evenodd;stroke-width:1pt"
+         sodipodi:nodetypes="cccc"
+         id="path838"
+         d="M 7.9956063,19.95977 C 8.3556614,19.98412 12.070639,20.508056 13.752377,19.634056 10.96728,19.990842 8.8086551,19.40555 8.4951087,19.450991 8.4215975,19.545133 8.137912,19.829967 7.9956063,19.95977 z"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:#ffffff;fill-rule:evenodd;stroke-width:1pt"
+         sodipodi:nodetypes="cccc"
+         id="path839"
+         d="m 9.5249794,18.352573 c 0.3600553,0.02435 4.4785196,0.179134 6.0642396,-0.08608 -2.160998,-0.203297 -5.2249,-0.46814 -5.538446,-0.422698 -0.073509,0.09414 -0.3834856,0.378975 -0.5257936,0.508777 z"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:#ffffff;fill-rule:evenodd;stroke-width:1pt"
+         sodipodi:nodetypes="cccc"
+         id="path840"
+         d="m 11.130939,16.76779 c 0.360058,0.02435 4.911754,0.718748 6.497476,0.356127 -2.233009,-0.251999 -5.63184,-0.884054 -5.94539,-0.838612 -0.07351,0.09414 -0.409778,0.352685 -0.552086,0.482485 z"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:#ffffff;fill-rule:evenodd;stroke-width:1pt"
+         sodipodi:nodetypes="cccc"
+         id="path841"
+         d="m 12.719762,15.38364 c 0.360057,0.02436 5.138061,0.883385 6.627767,0.569467 -1.584909,-0.154592 -5.683258,-1.149978 -5.996806,-1.104536 -0.07351,0.09414 -0.488655,0.405268 -0.630961,0.535069 z"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:#ffffff;fill-rule:evenodd;stroke-width:1pt"
+         sodipodi:nodetypes="cccc"
+         id="path842"
+         d="m 14.546332,13.969317 c 0.360057,0.02435 5.059186,0.935968 6.356863,0.76816 -1.776938,-0.130242 -5.373499,-1.172389 -5.687046,-1.126948 -0.121518,0.142847 -0.527509,0.228987 -0.669817,0.358788 z"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:#ffffff;fill-rule:evenodd;stroke-width:1pt"
+         sodipodi:nodetypes="cccc"
+         id="path843"
+         d="m 16.706669,12.826741 c 0.360055,0.02435 3.680697,0.714864 5.002378,0.741867 -1.800942,-0.27635 -3.942429,-1.148038 -4.255976,-1.102596 -0.07351,0.09414 -0.604095,0.230927 -0.746402,0.360729 z"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:#ffffff;fill-rule:evenodd;stroke-width:1pt"
+         sodipodi:nodetypes="cccc"
+         id="path844"
+         d="m 18.581243,11.923796 c 0.360057,0.02436 1.902139,0.424589 3.247822,0.183726 -1.464889,-0.03283 -2.362758,-0.543133 -2.676306,-0.497693 -0.07352,0.09414 -0.429209,0.184166 -0.571516,0.313967 z"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:#ffffff;fill-rule:evenodd;stroke-width:1pt"
+         sodipodi:nodetypes="cccc"
+         id="path845"
+         d="m 20.067185,10.902978 c 0.360059,0.02435 0.983132,-0.0868 1.488686,-0.425062 -0.696771,0.137625 -0.747644,-0.03175 -1.061192,0.01369 -0.07352,0.09414 -0.285186,0.281572 -0.427493,0.411373 z"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:#ffffff;fill-rule:evenodd;stroke-width:1pt"
+         sodipodi:nodetypes="cccc"
+         id="path846"
+         d="m 21.068478,9.8840968 c 0.360058,0.024345 0.80712,-0.6283437 0.90461,-1.1857757 C 21.732385,9.0307575 21.6895,9.2003596 21.56798,9.270152 21.494461,9.364296 21.210784,9.7542964 21.068478,9.8840968 z"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none"
+         sodipodi:nodetypes="cccc"
+         id="path857"
+         d="m 14.62506,12.949935 -0.631007,0.315503 c -0.07887,-0.157752 0.236627,-1.656393 0.867633,-2.050772 -0.315503,0.552131 -0.578423,1.735269 -0.236626,1.735269 z"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none"
+         sodipodi:nodetypes="cccc"
+         id="path858"
+         d="m 16.692543,11.832526 -0.446965,0.26292 c -0.07887,-0.157751 -0.05259,-0.893926 0.604716,-1.262014 -0.341796,0.341795 -0.499547,0.999094 -0.157751,0.999094 z"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none"
+         sodipodi:nodetypes="cccc"
+         id="path859"
+         d="m 18.585563,10.991184 -0.446964,0.262919 c -0.07888,-0.157751 0.499546,-0.841342 0.94651,-1.209429 -0.473254,0.604714 -0.604714,0.867635 -0.499546,0.94651 z"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none"
+         sodipodi:nodetypes="cccc"
+         id="path860"
+         d="m 20.057911,10.044673 -0.446963,0.262919 c -0.07887,-0.157751 0.525838,-0.6572972 0.972802,-1.0253842 -0.394378,0.4732548 -0.867635,0.7624662 -0.525839,0.7624652 z"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none"
+         sodipodi:nodetypes="cccc"
+         id="path861"
+         d="m 12.591,14.303969 -0.525841,0.368087 c -0.07887,-0.157751 0.02629,-1.866728 0.473254,-2.234815 -0.28921,0.604714 -0.289211,1.866728 0.05259,1.866728 z"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none"
+         sodipodi:nodetypes="cccc"
+         id="path862"
+         d="m 10.776853,15.881486 -0.394379,0.341796 c -0.07887,-0.157752 -0.02629,-1.708977 0.499547,-2.339984 -0.236626,0.473256 -0.446963,1.998187 -0.105168,1.998188 z"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none"
+         sodipodi:nodetypes="cccc"
+         id="path863"
+         d="m 9.0678792,17.432711 -0.3943809,0.341795 c -0.078875,-0.157751 0.1314593,-1.76156 0.5784233,-2.129647 -0.3155032,0.525838 -0.5258394,1.787853 -0.1840424,1.787852 z"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none"
+         sodipodi:nodetypes="cccc"
+         id="path864"
+         d="m 7.6744057,18.931351 -0.4469654,0.341796 c -0.05259,-0.210335 0.026291,-1.47235 0.4732563,-1.840436 -0.2629193,0.604714 -0.3680879,1.498641 -0.026291,1.49864 z"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none"
+         sodipodi:nodetypes="cccc"
+         id="path865"
+         d="M 6.3072229,20.37741 5.912844,20.719204 C 5.833972,20.561451 6.2020562,19.378314 6.5964335,18.878767 6.2809317,19.430899 5.9654279,20.377409 6.3072229,20.37741 z"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none"
+         sodipodi:nodetypes="cccc"
+         id="path866"
+         d="m 4.9926263,21.797174 -0.2629197,0.315502 c -0.078875,-0.157751 0.2892115,-0.736174 0.7624669,-1.288304 -0.078876,0.578422 -0.8413427,0.972802 -0.4995472,0.972802 z"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:#6d97c4;fill-opacity:1;fill-rule:evenodd;stroke:#2b3b4d;stroke-width:0.55514818;stroke-linejoin:round;stroke-opacity:1;stroke-dasharray:none"
+         sodipodi:nodetypes="cccccccccc"
+         id="path833"
+         d="m 17.821514,11.627108 c -1.556295,0.712455 -3.552564,1.600255 -5.222807,2.962778 -3.8148767,3.176348 -5.1101731,4.861848 -6.9294022,6.729867 0,0 -3.7932544,4.294941 -4.5419616,8.402111 -0.15378775,1.417771 0.6778602,1.199653 0.8824125,0.163589 0.7151549,-3.923111 2.8048552,-6.757751 4.1746633,-8.211256 1.6485183,-1.794709 3.277146,-4.053684 7.211596,-7.077315 1.465266,-1.22352 3.030762,-1.913435 4.613629,-2.638052 1.782122,-0.684766 2.095397,-1.390551 3.628194,-2.9355138 -0.631007,0.5258404 -2.260026,1.8913368 -3.816324,2.6037918 z"
+         inkscape:connector-curvature="0" />
+    </g>
     <g
-       id="orginal-6-9"
-       style="fill-rule:nonzero;stroke:#415a75;stroke-miterlimit:4;stroke-opacity:1"
-       transform="matrix(0.04360941,0,0,0.04360941,-58.563987,11.160611)" />
-    <path
-       inkscape:connector-curvature="0"
-       id="path2484-6"
-       style="fill-rule:nonzero;stroke:#415a75;stroke-width:0.13082823;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
-       d="" />
-    <g
-       style="fill:none;stroke:#415a75;stroke-miterlimit:4;stroke-opacity:1;filter:url(#filter4128-1)"
-       id="orginal-2"
-       transform="matrix(0.06061604,0,0,0.06061604,-30.427176,-2.3937558)" />
-    <g
-       id="orginal-6-1"
-       style="fill-rule:nonzero;stroke:#415a75;stroke-miterlimit:4;stroke-opacity:1"
-       transform="matrix(0.04953057,0,0,0.04953057,-28.815523,3.7399477)" />
-    <path
-       inkscape:connector-curvature="0"
-       id="path2484-3"
-       style="fill-rule:nonzero;stroke:#415a75;stroke-width:0.14859173;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
-       d="" />
-    <g
-       style="fill:none;stroke:#415a75;stroke-miterlimit:4;stroke-opacity:1;filter:url(#filter4128-5-6)"
-       id="orginal-61-8"
-       transform="matrix(0.06061604,0,0,0.06061604,-69.711706,2.8976297)" />
-    <g
-       id="orginal-6-9-7"
-       style="fill-rule:nonzero;stroke:#415a75;stroke-miterlimit:4;stroke-opacity:1"
-       transform="matrix(0.04953057,0,0,0.04953057,-68.100053,9.0313334)" />
-    <path
-       inkscape:connector-curvature="0"
-       id="path2484-6-1"
-       style="fill-rule:nonzero;stroke:#415a75;stroke-width:0.14859173;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
-       d="" />
-    <g
+       style="display:inline"
        id="g5023"
-       transform="matrix(1.4683677,0,0,1.4683677,-9.4680718,-20.588948)">
+       transform="matrix(0.93590871,0,0,0.93590871,7.0476183,-0.99125544)">
       <path
          sodipodi:nodetypes="cccccccc"
          style="fill:none;stroke:#000000;stroke-linecap:round;stroke-linejoin:round"
@@ -695,23 +392,6 @@
          id="path4511"
          d="M 10.414538,21.286344 10.200882,29.987226 7.8764706,30.24902 12.5,34.5 l 5.048481,-4.356294 -3.047311,0 0.04273,-9.170618 z"
          style="fill:#55d400;stroke:none" />
-    </g>
-    <g
-       id="g3864"
-       transform="matrix(0.88018265,0.20942954,-0.20942954,0.88018265,31.97733,7.0986861)">
-      <path
-         sodipodi:nodetypes="ccc"
-         transform="translate(0,8)"
-         inkscape:connector-curvature="0"
-         id="path3862"
-         d="M -15.498039,21.741177 C -14.1814,14.300714 -4.4871385,9.5283472 -4.5176471,10.321569 -8.103254,14.167559 -6.6965798,20.656521 -15.498039,21.741177 z"
-         style="fill:#5f8dd3;stroke:#000000;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-      <path
-         sodipodi:nodetypes="cccc"
-         inkscape:connector-curvature="0"
-         id="path3092"
-         d="m -17.443137,32.439216 c 2.258823,-5.145098 12.1098037,-13.678432 12.1098037,-13.678432 -3.5209365,3.973139 -7.2553877,7.305733 -10.4784317,12.172549 z"
-         style="fill:#3771c8;stroke:#000000;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
     </g>
   </g>
 </svg>

--- a/checkout_pg.svg
+++ b/checkout_pg.svg
@@ -7,7 +7,6 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="24"
@@ -15,7 +14,7 @@
    id="svg5692"
    version="1.1"
    inkscape:version="0.48.4 r9939"
-   sodipodi:docname="checkout_pg.svg"
+   sodipodi:docname="chceckout_pg_main.svg"
    inkscape:export-filename="/home/denis/Desktop/oracle.png"
    inkscape:export-xdpi="67.5"
    inkscape:export-ydpi="67.5">
@@ -120,424 +119,6 @@
        inkscape:vp_y="0 : 1000 : 0"
        inkscape:vp_x="0 : 278.36438 : 1"
        sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 278.36438 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="540.08875 : 278.36438 : 1"
-       inkscape:persp3d-origin="270.04437 : 185.57625 : 1"
-       id="perspective2491-7" />
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 278.36438 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="540.08875 : 278.36438 : 1"
-       inkscape:persp3d-origin="270.04437 : 185.57625 : 1"
-       id="perspective2850-3" />
-    <filter
-       color-interpolation-filters="sRGB"
-       id="filter4128-5"
-       inkscape:label="Drop shadow"
-       width="1.5"
-       height="1.5"
-       x="-0.25"
-       y="-0.25">
-      <feGaussianBlur
-         id="feGaussianBlur4130-3"
-         in="SourceAlpha"
-         stdDeviation="2.000000"
-         result="blur" />
-      <feColorMatrix
-         id="feColorMatrix4132-0"
-         result="bluralpha"
-         type="matrix"
-         values="1 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 0.351000 0 " />
-      <feOffset
-         id="feOffset4134-1"
-         in="bluralpha"
-         dx="7.500000"
-         dy="7.500000"
-         result="offsetBlur" />
-      <feMerge
-         id="feMerge4136-0">
-        <feMergeNode
-           id="feMergeNode4138-7"
-           in="offsetBlur" />
-        <feMergeNode
-           id="feMergeNode4140-7"
-           in="SourceGraphic" />
-      </feMerge>
-    </filter>
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       id="perspective4762-2" />
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       id="perspective9811-1" />
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       id="perspective8710-5" />
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       id="perspective7871-7" />
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       id="perspective3600-7" />
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       id="perspective3496-6" />
-    <inkscape:perspective
-       id="perspective3486-0"
-       inkscape:persp3d-origin="16 : 10.666667 : 1"
-       inkscape:vp_z="32 : 16 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 16 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <linearGradient
-       id="linearGradient3906-7-3"
-       inkscape:collect="always">
-      <stop
-         id="stop3908-6-3"
-         offset="0"
-         style="stop-color:#2c89a0;stop-opacity:1;" />
-      <stop
-         id="stop3910-2-1"
-         offset="1"
-         style="stop-color:#2c89a0;stop-opacity:0;" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3906-7-3"
-       id="linearGradient3969-7"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(0.62114454,11.887986)"
-       x1="8.3854542"
-       y1="10.024242"
-       x2="20.941452"
-       y2="9.7580376" />
-    <linearGradient
-       id="linearGradient3906-7-5"
-       inkscape:collect="always">
-      <stop
-         id="stop3908-6-6"
-         offset="0"
-         style="stop-color:#2c89a0;stop-opacity:1;" />
-      <stop
-         id="stop3910-2-4"
-         offset="1"
-         style="stop-color:#2c89a0;stop-opacity:0;" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3906-7-5"
-       id="linearGradient3969-5"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(0.62114454,11.887986)"
-       x1="8.3854542"
-       y1="10.024242"
-       x2="20.941452"
-       y2="9.7580376" />
-    <linearGradient
-       id="linearGradient3906-7"
-       inkscape:collect="always">
-      <stop
-         id="stop3908-6"
-         offset="0"
-         style="stop-color:#2c89a0;stop-opacity:1;" />
-      <stop
-         id="stop3910-2"
-         offset="1"
-         style="stop-color:#2c89a0;stop-opacity:0;" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="translate(0.53240981,11.904339)"
-       gradientUnits="userSpaceOnUse"
-       y2="9.7580376"
-       x2="20.941452"
-       y1="10.024242"
-       x1="8.3854542"
-       id="linearGradient3916-6"
-       xlink:href="#linearGradient3906-7"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientUnits="userSpaceOnUse"
-       y2="13.18094"
-       x2="22.520084"
-       y1="11.470613"
-       x1="6.6438971"
-       id="linearGradient3952"
-       xlink:href="#linearGradient3906"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(0.53240981,3.9043386)"
-       gradientUnits="userSpaceOnUse"
-       y2="17.758038"
-       x2="20.941452"
-       y1="18.024242"
-       x1="8.3854542"
-       id="linearGradient3914"
-       xlink:href="#linearGradient3906"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(0.53240981,3.9043386)"
-       gradientUnits="userSpaceOnUse"
-       y2="17.758038"
-       x2="20.941452"
-       y1="18.024242"
-       x1="8.3854542"
-       id="linearGradient3912"
-       xlink:href="#linearGradient3906"
-       inkscape:collect="always" />
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 16 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="32 : 16 : 1"
-       inkscape:persp3d-origin="16 : 10.666667 : 1"
-       id="perspective3486-0-3" />
-    <inkscape:perspective
-       id="perspective3496-6-2"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective3600-7-2"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective7871-7-6"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective8710-5-5"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective9811-1-9"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective4762-2-8"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <filter
-       y="-0.25"
-       x="-0.25"
-       height="1.5"
-       width="1.5"
-       inkscape:label="Drop shadow"
-       id="filter4128-5-6"
-       color-interpolation-filters="sRGB">
-      <feGaussianBlur
-         result="blur"
-         stdDeviation="2.000000"
-         in="SourceAlpha"
-         id="feGaussianBlur4130-3-6" />
-      <feColorMatrix
-         values="1 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 0.351000 0 "
-         type="matrix"
-         result="bluralpha"
-         id="feColorMatrix4132-0-9" />
-      <feOffset
-         result="offsetBlur"
-         dy="7.500000"
-         dx="7.500000"
-         in="bluralpha"
-         id="feOffset4134-1-7" />
-      <feMerge
-         id="feMerge4136-0-6">
-        <feMergeNode
-           in="offsetBlur"
-           id="feMergeNode4138-7-5" />
-        <feMergeNode
-           in="SourceGraphic"
-           id="feMergeNode4140-7-9" />
-      </feMerge>
-    </filter>
-    <inkscape:perspective
-       id="perspective2850-3-6"
-       inkscape:persp3d-origin="270.04437 : 185.57625 : 1"
-       inkscape:vp_z="540.08875 : 278.36438 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 278.36438 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective2491-7-1"
-       inkscape:persp3d-origin="270.04437 : 185.57625 : 1"
-       inkscape:vp_z="540.08875 : 278.36438 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 278.36438 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 278.36438 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="540.08875 : 278.36438 : 1"
-       inkscape:persp3d-origin="270.04437 : 185.57625 : 1"
-       id="perspective2491-2" />
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 278.36438 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="540.08875 : 278.36438 : 1"
-       inkscape:persp3d-origin="270.04437 : 185.57625 : 1"
-       id="perspective2850-9" />
-    <filter
-       color-interpolation-filters="sRGB"
-       id="filter4128-1"
-       inkscape:label="Drop shadow"
-       width="1.5"
-       height="1.5"
-       x="-0.25"
-       y="-0.25">
-      <feGaussianBlur
-         id="feGaussianBlur4130-4"
-         in="SourceAlpha"
-         stdDeviation="2.000000"
-         result="blur" />
-      <feColorMatrix
-         id="feColorMatrix4132-3"
-         result="bluralpha"
-         type="matrix"
-         values="1 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 0.351000 0 " />
-      <feOffset
-         id="feOffset4134-6"
-         in="bluralpha"
-         dx="7.500000"
-         dy="7.500000"
-         result="offsetBlur" />
-      <feMerge
-         id="feMerge4136-1">
-        <feMergeNode
-           id="feMergeNode4138-1"
-           in="offsetBlur" />
-        <feMergeNode
-           id="feMergeNode4140-3"
-           in="SourceGraphic" />
-      </feMerge>
-    </filter>
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       id="perspective4762-27" />
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       id="perspective9811-2" />
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       id="perspective8710-50" />
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       id="perspective7871-5" />
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       id="perspective3600-75" />
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       id="perspective3496-1" />
-    <inkscape:perspective
-       id="perspective3486-7"
-       inkscape:persp3d-origin="16 : 10.666667 : 1"
-       inkscape:vp_z="32 : 16 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 16 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <linearGradient
-       id="linearGradient3906"
-       inkscape:collect="always">
-      <stop
-         id="stop3908"
-         offset="0"
-         style="stop-color:#2c89a0;stop-opacity:1;" />
-      <stop
-         id="stop3910"
-         offset="1"
-         style="stop-color:#2c89a0;stop-opacity:0;" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3906-7"
-       id="linearGradient3126"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(0.62114454,11.887986)"
-       x1="8.3854542"
-       y1="10.024242"
-       x2="20.941452"
-       y2="9.7580376" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3906-7-5"
-       id="linearGradient3128"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(0.62114454,11.887986)"
-       x1="8.3854542"
-       y1="10.024242"
-       x2="20.941452"
-       y2="9.7580376" />
   </defs>
   <sodipodi:namedview
      id="base"
@@ -546,20 +127,20 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="11.269514"
-     inkscape:cx="15.798706"
-     inkscape:cy="3.8788151"
+     inkscape:zoom="15.9375"
+     inkscape:cx="-2.6478579"
+     inkscape:cy="9.3227386"
      inkscape:current-layer="layer2"
      showgrid="true"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
      borderlayer="false"
-     inkscape:window-width="1600"
-     inkscape:window-height="850"
-     inkscape:window-x="0"
-     inkscape:window-y="28"
-     inkscape:window-maximized="1"
-     inkscape:snap-global="false"
+     inkscape:window-width="1035"
+     inkscape:window-height="631"
+     inkscape:window-x="14"
+     inkscape:window-y="762"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="true"
      showguides="true"
      inkscape:guide-bbox="true"
      inkscape:snap-object-midpoints="false"
@@ -637,52 +218,54 @@
        style="fill-rule:nonzero;stroke:#415a75;stroke-miterlimit:4;stroke-opacity:1"
        transform="matrix(0.04360941,0,0,0.04360941,-23.975751,6.5017873)" />
     <path
+       id="path2464"
+       d="m 16.943823,18.994826 c -2.147617,0.427357 -2.295248,-0.274103 -2.295248,-0.274103 2.267537,-3.245893 3.215439,-7.366072 2.397413,-8.374462 C 14.814358,7.595563 10.951279,8.8964658 10.88681,8.9302395 l -0.02073,0.00358 C 10.441774,8.8488498 9.9669246,8.7982305 9.4332448,8.7898282 8.461476,8.7744675 7.724357,9.0355932 7.1650193,9.4447893 c 0,0 -6.8913451,-2.7387533 -6.57083865,3.4444997 0.0681858,1.315442 1.95437885,9.953219 4.20416025,7.344203 0.822294,-0.954026 1.6167929,-1.76068 1.6167929,-1.76068 0.394625,0.25289 0.8670373,0.381893 1.3622937,0.335557 l 0.038446,-0.03149 c -0.011969,0.118453 -0.00596,0.234316 0.015449,0.371468 -0.5795762,0.624685 -0.4092707,0.734371 -1.5678682,0.964444 -1.1723459,0.233081 -0.4836426,0.648042 -0.033983,0.756486 0.5451225,0.131515 1.8062707,0.317803 2.6584109,-0.83297 l -0.03401,0.131304 c 0.2270916,0.175458 0.3865517,1.141344 0.3598278,2.016902 -0.026734,0.875602 -0.044574,1.476732 0.134356,1.946269 0.1789333,0.469535 0.3572721,1.525993 1.88035,1.211155 1.272676,-0.263103 1.932177,-0.944922 2.023924,-2.082229 0.0651,-0.808549 0.212447,-0.68902 0.221755,-1.411902 l 0.118181,-0.342226 c 0.136285,-1.096038 0.02165,-1.449634 0.805732,-1.285169 l 0.190543,0.01616 c 0.577103,0.02529 1.332408,-0.08954 1.775707,-0.288308 0.954558,-0.427364 1.52069,-1.140889 0.579487,-0.953404 l 8.6e-5,0 z"
+       style="fill:#6e97c4;fill-opacity:1;stroke:#415a75;stroke-width:1.13618422;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#6e97c4;fill-opacity:1;stroke:#2e4e72;stroke-width:1.13618422000000008;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="path2466"
+       d="m 8.9800819,19.6231 c -0.059111,2.039431 0.014875,4.093073 0.2217131,4.592185 0.2069822,0.499109 0.649934,1.469888 2.173142,1.155099 1.272553,-0.263191 1.735572,-0.772514 1.936493,-1.896721 0.147975,-0.827128 0.433261,-3.124227 0.469847,-3.594874"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#6e97c4;fill-opacity:1;stroke:#2e4e72;stroke-width:1.13618422000000008;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="path2468"
+       d="m 7.1543834,9.3992398 c 0,0 -6.89604175,-2.7190246 -6.57544988,3.4642282 0.0681794,1.315442 1.95450678,9.953506 4.20424498,7.344363 0.8221234,-0.954142 1.5656462,-1.702475 1.5656462,-1.702475"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#6e97c4;fill-opacity:1;stroke:#2e4e72;stroke-width:1.13618422000000008;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="path2470"
+       d="m 10.879253,8.9029733 c -0.238703,0.0722 3.836009,-1.4369857 6.151709,1.4175457 0.817985,1.008431 -0.129918,5.12861 -2.397418,8.374587"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path2472"
+       d="m 14.6335,18.695106 c 0,0 0.147765,0.701668 2.295421,0.274019 0.940984,-0.187485 0.37469,0.526126 -0.579658,0.953694 -0.783232,0.350667 -2.539208,0.440538 -2.567898,-0.04403 C 13.7076,18.628545 14.70557,19.008377 14.633544,18.695106 14.56846,18.412968 14.122105,18.13607 13.826877,17.445564 13.569133,16.842868 10.291947,12.220987 14.73571,12.907415 14.898505,12.874917 13.576727,8.8297844 9.4179966,8.7640084 5.2602028,8.6982326 5.3966115,13.696689 5.3966115,13.696689"
+       style="fill:#6e97c4;fill-opacity:1;stroke:#2e4e72;stroke-width:1.13618422000000008;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#6e97c4;fill-opacity:1;stroke:#2e4e72;stroke-width:1.13618422000000008;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="path2474"
+       d="M 7.8161473,19.122668 C 7.236484,19.747321 7.4069612,19.857 6.2482799,20.087152 5.0759341,20.320273 5.7647232,20.735155 6.2142519,20.843558 6.7593739,20.975153 8.0205211,21.161449 8.8726583,20.010385 9.1321525,19.65992 8.8711883,19.100719 8.5146623,18.95817 8.342431,18.88933 8.1121414,18.803101 7.8161425,19.122668 l 0,0 z"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#6e97c4;fill-opacity:1;stroke:#2e4e72;stroke-width:1.13618422000000008;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="path2476"
+       d="M 7.7781911,19.111752 C 7.7197791,18.744488 7.9032859,18.307451 8.0999377,17.796152 8.395468,17.028998 9.0773367,16.261714 8.5318773,13.8282 8.1252992,12.014761 5.3982767,13.4508 5.3965691,13.696688 c -0.00168,0.245806 0.1233439,1.24633 -0.045552,2.411438 -0.2203878,1.520349 1.0028061,2.806178 2.4113336,2.674624"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#7eb2e5;fill-opacity:1;stroke:#2e4e72;stroke-width:1.13618422000000008;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="path2482"
+       d="m 14.735712,12.907415 c 0.03683,0.658751 -0.147081,1.107446 -0.170264,1.808702 -0.03436,1.019307 0.50375,2.185975 -0.307014,3.354093"
+       inkscape:connector-curvature="0" />
+    <path
        inkscape:connector-curvature="0"
        id="path2484"
        style="fill-rule:nonzero;stroke:#415a75;stroke-width:0.13082823;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
        d="" />
     <g
-       style="fill:none;stroke:#415a75;stroke-miterlimit:4;stroke-opacity:1;filter:url(#filter4128-5)"
-       id="orginal-61"
-       transform="matrix(0.05336966,0,0,0.05336966,-59.982974,5.7601648)" />
-    <g
-       id="orginal-6-9"
-       style="fill-rule:nonzero;stroke:#415a75;stroke-miterlimit:4;stroke-opacity:1"
-       transform="matrix(0.04360941,0,0,0.04360941,-58.563987,11.160611)" />
-    <path
-       inkscape:connector-curvature="0"
-       id="path2484-6"
-       style="fill-rule:nonzero;stroke:#415a75;stroke-width:0.13082823;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
-       d="" />
-    <g
-       style="fill:none;stroke:#415a75;stroke-miterlimit:4;stroke-opacity:1;filter:url(#filter4128-1)"
-       id="orginal-2"
-       transform="matrix(0.06061604,0,0,0.06061604,-30.427176,-2.3937558)" />
-    <g
-       id="orginal-6-1"
-       style="fill-rule:nonzero;stroke:#415a75;stroke-miterlimit:4;stroke-opacity:1"
-       transform="matrix(0.04953057,0,0,0.04953057,-28.815523,3.7399477)" />
-    <path
-       inkscape:connector-curvature="0"
-       id="path2484-3"
-       style="fill-rule:nonzero;stroke:#415a75;stroke-width:0.14859173;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
-       d="" />
-    <g
-       style="fill:none;stroke:#415a75;stroke-miterlimit:4;stroke-opacity:1;filter:url(#filter4128-5-6)"
-       id="orginal-61-8"
-       transform="matrix(0.06061604,0,0,0.06061604,-69.711706,2.8976297)" />
-    <g
-       id="orginal-6-9-7"
-       style="fill-rule:nonzero;stroke:#415a75;stroke-miterlimit:4;stroke-opacity:1"
-       transform="matrix(0.04953057,0,0,0.04953057,-68.100053,9.0313334)" />
-    <path
-       inkscape:connector-curvature="0"
-       id="path2484-6-1"
-       style="fill-rule:nonzero;stroke:#415a75;stroke-width:0.14859173;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
-       d="" />
-    <g
+       style="display:inline"
        id="g5023"
-       transform="matrix(1.4683677,0,0,1.4683677,-9.7179703,-21.001864)">
+       transform="matrix(0.93358368,0,0,0.93358368,6.8038909,-0.70987938)">
       <path
          sodipodi:nodetypes="cccccccc"
          style="fill:none;stroke:#000000;stroke-linecap:round;stroke-linejoin:round"
@@ -695,38 +278,6 @@
          id="path4511"
          d="M 10.414538,21.286344 10.200882,29.987226 7.8764706,30.24902 12.5,34.5 l 5.048481,-4.356294 -3.047311,0 0.04273,-9.170618 z"
          style="fill:#55d400;stroke:none" />
-    </g>
-    <g
-       id="g4601"
-       transform="translate(0.70987977,-0.08873497)">
-      <g
-         transform="matrix(0.90231527,0,0,0.90231527,29.980489,5.1271357)"
-         id="g3885">
-        <path
-           style="fill:#3771c8;stroke:#3771c8;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-           d="m -16.501961,22.4 c 3.576471,-2.007843 6.025977,-0.702229 7.0901962,0.501961 1.9082481,2.159229 0.3905025,6.225797 0.3764705,6.211765 l -1.9450977,0.12549 -0.06274,-2.447059 c -1.003922,0.5855 -2.007844,0.477646 -3.011765,0.06274 l -0.627451,2.133333 -2.007843,0 z"
-           id="path3113"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="csccccccc" />
-        <path
-           sodipodi:nodetypes="cscscccc"
-           inkscape:connector-curvature="0"
-           id="path3883"
-           d="m -20.663274,26.609596 c 0,0 1.429934,-5.311183 2.723684,-5.515458 1.517429,-0.239594 2.859868,-1.089473 2.859868,-1.089473 0,0 2.383222,3.064143 0.749013,4.357892 -1.634211,1.293749 -2.24704,-0.68092 -2.24704,-0.68092 0,0 -1.087347,-0.206403 -2.178946,0.885197 l -1.702302,2.110854 z"
-           style="fill:#ffffff;stroke:#ffffff;stroke-width:1.08521748px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-        <path
-           style="fill:#3771c8;stroke:#3771c8;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-           d="m -20.392157,26.352941 c 0,0 1.317647,-4.894118 2.509804,-5.082353 1.398272,-0.220779 2.635295,-1.003921 2.635295,-1.003921 0,0 2.196078,2.823529 0.690196,4.015685 -1.505883,1.192157 -2.070589,-0.62745 -2.070589,-0.62745 0,0 -1.001962,-0.190195 -2.007843,0.815686 l -1.568627,1.945098 z"
-           id="path3111"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cscscccc" />
-      </g>
-      <path
-         sodipodi:nodetypes="cc"
-         inkscape:connector-curvature="0"
-         id="path3892"
-         d="m 13.402595,25.18564 c 0,0 -0.107151,-0.237948 0.363437,-0.237948"
-         style="fill:#afc6e9;stroke:#000080;stroke-width:0.37577835;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
     </g>
   </g>
 </svg>

--- a/commit.svg
+++ b/commit.svg
@@ -15,7 +15,7 @@
    id="svg5692"
    version="1.1"
    inkscape:version="0.48.4 r9939"
-   sodipodi:docname="commit.svg"
+   sodipodi:docname="commit_main.svg"
    inkscape:export-filename="/home/denis/Desktop/oracle.png"
    inkscape:export-xdpi="67.5"
    inkscape:export-ydpi="67.5">
@@ -528,16 +528,16 @@
      inkscape:pageshadow="2"
      inkscape:zoom="15.9375"
      inkscape:cx="12.151688"
-     inkscape:cy="6.388619"
+     inkscape:cy="8.8984229"
      inkscape:current-layer="layer2"
      showgrid="true"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
      borderlayer="false"
-     inkscape:window-width="1600"
-     inkscape:window-height="850"
+     inkscape:window-width="1280"
+     inkscape:window-height="696"
      inkscape:window-x="0"
-     inkscape:window-y="28"
+     inkscape:window-y="24"
      inkscape:window-maximized="1"
      inkscape:snap-global="false"
      showguides="true"
@@ -660,9 +660,44 @@
        id="path2484-6-1"
        style="fill-rule:nonzero;stroke:#415a75;stroke-width:0.14859173;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
        d="" />
+    <path
+       id="path2464"
+       d="m 17.044623,25.038456 c -2.147617,0.427357 -2.295248,-0.274103 -2.295248,-0.274103 2.267537,-3.245893 3.215439,-7.366072 2.397413,-8.374462 -2.23163,-2.750699 -6.09471,-1.449796 -6.159179,-1.416022 l -0.02073,0.0036 c -0.424306,-0.08497 -0.899155,-0.135589 -1.4328346,-0.143991 -0.971769,-0.01536 -1.708888,0.245765 -2.268225,0.654961 0,0 -6.89134499,-2.738754 -6.57083899,3.4445 0.06819,1.315442 1.95437899,9.953219 4.20415999,7.344203 0.822294,-0.954026 1.616793,-1.76068 1.616793,-1.76068 0.394625,0.25289 0.867037,0.381893 1.362294,0.335557 l 0.03845,-0.03149 c -0.01197,0.118453 -0.006,0.234316 0.01545,0.371468 -0.579576,0.624685 -0.409271,0.734371 -1.567868,0.964444 -1.172346,0.233081 -0.483643,0.648042 -0.03398,0.756486 0.545122,0.131515 1.80627,0.317803 2.658411,-0.83297 l -0.03401,0.131304 c 0.227091,0.175458 0.386551,1.141344 0.359827,2.016902 -0.02673,0.875602 -0.04457,1.476732 0.134356,1.946269 0.178934,0.469535 0.357272,1.525993 1.8803496,1.211155 1.272677,-0.263103 1.932178,-0.944922 2.023925,-2.082229 0.0651,-0.808549 0.212447,-0.68902 0.221755,-1.411902 l 0.118181,-0.342226 c 0.136285,-1.096038 0.02165,-1.449634 0.805732,-1.285169 l 0.190543,0.01616 c 0.577103,0.02529 1.332408,-0.08954 1.775707,-0.288308 0.954558,-0.427364 1.52069,-1.140889 0.579487,-0.953404 l 8.6e-5,0 z"
+       style="fill:#6e97c4;fill-opacity:1;stroke:#415a75;stroke-width:1.13618422;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#6e97c4;fill-opacity:1;stroke:#2e4e72;stroke-width:1.13618422;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       id="path2468"
+       d="m 7.2551834,15.442869 c 0,0 -6.89604199,-2.719024 -6.57544999,3.464229 0.06818,1.315442 1.95450699,9.953506 4.20424499,7.344363 0.822123,-0.954142 1.565646,-1.702475 1.565646,-1.702475"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#6e97c4;fill-opacity:1;stroke:#2e4e72;stroke-width:1.13618422;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       id="path2470"
+       d="m 10.980052,14.946603 c -0.238703,0.0722 3.83601,-1.436986 6.15171,1.417546 0.817985,1.008431 -0.129918,5.12861 -2.397418,8.374587"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path2472"
+       d="m 14.7343,24.738736 c 0,0 0.147765,0.701668 2.295421,0.274019 0.940984,-0.187485 0.37469,0.526126 -0.579658,0.953694 -0.783232,0.350667 -2.539208,0.440538 -2.567898,-0.04403 -0.07376,-1.250244 0.924205,-0.870412 0.852179,-1.183683 -0.06508,-0.282138 -0.511439,-0.559036 -0.806667,-1.249542 -0.257744,-0.602696 -3.534931,-5.224577 0.908833,-4.538149 0.162795,-0.0325 -1.158983,-4.077631 -5.3177136,-4.143407 -4.157794,-0.06578 -4.021385,4.932681 -4.021385,4.932681"
+       style="fill:#6e97c4;fill-opacity:1;stroke:#2e4e72;stroke-width:1.13618422;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#6e97c4;fill-opacity:1;stroke:#2e4e72;stroke-width:1.13618422;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       id="path2474"
+       d="m 7.9169474,25.166298 c -0.579664,0.624653 -0.409186,0.734332 -1.567868,0.964484 -1.172346,0.233121 -0.483556,0.648003 -0.03403,0.756406 0.545122,0.131595 1.806269,0.317891 2.658407,-0.833173 0.259494,-0.350465 -0.0015,-0.909666 -0.357996,-1.052215 -0.172232,-0.06884 -0.402521,-0.155069 -0.69852,0.164498 l 0,0 z"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#6e97c4;fill-opacity:1;stroke:#2e4e72;stroke-width:1.13618422;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       id="path2476"
+       d="m 7.8789904,25.155382 c -0.05841,-0.367264 0.125095,-0.804301 0.321747,-1.3156 0.29553,-0.767154 0.977399,-1.534438 0.43194,-3.967952 -0.406578,-1.813439 -3.133601,-0.3774 -3.135309,-0.131512 -0.0017,0.245806 0.123344,1.24633 -0.04555,2.411438 -0.220387,1.520349 1.002807,2.806178 2.411334,2.674624"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#7eb2e5;fill-opacity:1;stroke:#2e4e72;stroke-width:1.13618422;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       id="path2482"
+       d="m 14.836512,18.951045 c 0.03683,0.658751 -0.147081,1.107446 -0.170264,1.808702 -0.03436,1.019307 0.50375,2.185975 -0.307014,3.354093"
+       inkscape:connector-curvature="0" />
     <g
        id="g5023"
-       transform="matrix(1.4683677,0,0,-1.4683677,-6.0798365,60.5817)">
+       transform="matrix(0.93358364,0,0,-0.93358366,6.9871381,40.842109)">
       <path
          sodipodi:nodetypes="cccccccc"
          style="fill:none;stroke:#000000;stroke-linecap:round;stroke-linejoin:round"


### PR DESCRIPTION
This is a suggestion to replace existing icons so as to make them clearer and more in line with other QGIS menus.  Disclaimer : I have modified the original svg files using Inkscape and some information pertaining to the initial filenames persist in the files.  The icons show up OK in QGIS, but there may be some cleanup required in the svg markup if we do adopt the new icons.

Some users feel the checkout buttons  (spatialite vs PG) are hard to differentiate from each other.  We have modified the tooltip text to help, but that is not enough and so we propose to also change the icons.  We have combined the existing *Add vector layer* icons for spatialite and PG that show up on the left handside in QGIS with the current plugin icons.  The idea was : 

1) use graphic elements similar to the main QGIS visual artifacts
2) make the plugin icons clearer

As a result, the spatialite checkout and postGIS checkout buttons are now much easier to identify.  Following along those lines, we combined the commit plugin button with the PG elephant.  We believe that makes it clearer for users that commit can only be towards PG.  Of course, this brings the question of whether to bring the elephant to all icons that are limited to PG (e.g. view, historize, branch).  That may mean too many elephants in the menu, but at any rate we believe differentiating between checkout buttons is a minimum.

Question : I haven't checked specific license information on the "Add vector layers" QGIS icons.  I suspect they are rather open, but I have not checked.

Thanx for your input.