### PR TITLE
Clearer UI for view button

### DIFF
--- a/versioning.py
+++ b/versioning.py
@@ -398,6 +398,12 @@ class Versioning:
         button_box.rejected.connect(dlg.reject)
 
         pcur = versioning_base.Db( psycopg2.connect(self.pg_conn_info()) )
+        user_msg1 = QgsMessageBar(dlg)
+        user_msg1.pushInfo("Click:", "one row for single revision; "
+        "control+click for multiple revisions.")
+        user_msg2 = QgsMessageBar(dlg)
+        user_msg2.pushWarning("Note:", "Upon clicking \"OK\", "
+            "fetching revisions may take some time.")
         pcur.execute("SELECT rev, commit_msg, branch, date, author "
             "FROM "+schema+".revisions")
         revs = pcur.fetchall()
@@ -412,9 +418,11 @@ class Versioning:
         for i, rev in enumerate(revs):
             for j, item in enumerate(rev):
                 tblw.setItem(i, j, QTableWidgetItem( str(item) ))
+        layout.addWidget( user_msg1 )
         layout.addWidget( tblw )
+        layout.addWidget( user_msg2 )
         layout.addWidget( button_box )
-        dlg.resize( 600, 300 )
+        dlg.resize( 650, 300 )
         if not dlg.exec_() :
             return
 


### PR DESCRIPTION
In relation to GISeHealth#25, this PR prepends the table popped up by clicking the view button with checkboxes (first column) to make it clearer for users which revision(s) they will fetch.  

One other issue we had was the fact that the UI did not display any sign of activity while fetching data.  To alleviate that, we : 

- added a new message at the top of the revisions table to warn the user that fetching may take some time
- added a progress bar

The progress bar isn't very representative of real time left, but at least it gives the user some feedback that something is transferring.  

This is just an enhancement to the current behaviour.  No "diff mode" included yet.
