### PR TITLE
Refacto 2nd round: use only super class versioning

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -42,7 +42,6 @@ from qgis.core import QgsCredentials, QgsDataSourceURI, QgsMapLayerRegistry, \
     QgsRuleBasedRendererV2
 from PyQt4.QtCore import *
 
-from .versioningDB.versioningAbc import versioningAbc
 from .versioningDB import versioning
 
 
@@ -738,9 +737,9 @@ class Plugin(QObject):
         uri = QgsDataSourceURI(layer.source())
 
         if layer.providerType() == 'spatialite':
-            self.versioning = versioningAbc([uri.database(), self.pg_conn_info()], layer.providerType())
+            self.versioning = versioning.versioningDb([uri.database(), self.pg_conn_info()], layer.providerType())
         else:
-            self.versioning = versioningAbc([self.pg_conn_info(), uri.schema()], layer.providerType())
+            self.versioning = versioning.versioningDb([self.pg_conn_info(), uri.schema()], layer.providerType())
             
         
         unresolved = self.versioning.unresolved_conflicts()
@@ -920,7 +919,7 @@ class Plugin(QObject):
             os.remove(filename)
 
         print "checking out ", tables_for_conninfo, " from ",uri.connectionInfo()
-        self.versioning = versioningAbc([filename, self.pg_conn_info()], 'spatialite')
+        self.versioning = versioning.versioningDb([filename, self.pg_conn_info()], 'spatialite')
         self.versioning.checkout(tables_for_conninfo, user_selected_features )
 
         # add layers from offline version
@@ -1024,7 +1023,7 @@ class Plugin(QObject):
             "<b>lowercase</b> letters, underscore or digits.", duration=10)
             return
         print "checking out ", tables_for_conninfo, " from ", uri.connectionInfo()
-        self.versioning = versioningAbc([self.pg_conn_info(), working_copy_schema], 'postgres')
+        self.versioning = versioning.versioningDb([self.pg_conn_info(), working_copy_schema], 'postgres')
         self.versioning.checkout(tables_for_conninfo, user_selected_features )
 
         # add layers from offline version

--- a/plugin.py
+++ b/plugin.py
@@ -42,8 +42,7 @@ from qgis.core import QgsCredentials, QgsDataSourceURI, QgsMapLayerRegistry, \
     QgsRuleBasedRendererV2
 from PyQt4.QtCore import *
 
-from .versioningDB.spatialite import spVersioning
-from .versioningDB.postgresqlLocal import pgVersioning
+from .versioningDB.versioningAbc import versioningAbc
 from .versioningDB import versioning
 
 
@@ -104,8 +103,7 @@ class Plugin(QObject):
             self.legend = self.iface.mainWindow().findChild( QTreeView, 'theLayerTreeView')
             self.legend.clicked.connect(self.on_legend_click)
 
-        self.spversioning = spVersioning()
-        self.pgversioning = pgVersioning()
+        self.versioning = None
         
     def enable_diffmode(self):
         '''This function enables the diffmode checkbox iif the number of checked
@@ -310,7 +308,7 @@ class Plugin(QObject):
         if layer.providerType() == "spatialite":
             rev = 0
             try:
-                rev = self.spversioning.revision( uri.database() )
+                rev = self.versioning.revision()
             except:
                 self.current_layers = []
                 self.info.setText("Versioning : the selected group is not a working copy")
@@ -332,8 +330,7 @@ class Plugin(QObject):
                 # check if it's a working copy
                 rev = 0
                 try:
-                    rev = self.pgversioning.revision( [self.pg_conn_info(),
-                                                       uri.schema()] )
+                    rev = self.versioning.revision()
                     selection_type = 'working copy'
                     self.info.setText( uri.database()+' '+uri.schema()
                             +' <b>working rev</b>='+str(rev) )
@@ -740,8 +737,14 @@ class Plugin(QObject):
                 self.current_layers[0] )
         uri = QgsDataSourceURI(layer.source())
 
+        if layer.providerType() == 'spatialite':
+            self.versioning = versioningAbc([uri.database(), self.pg_conn_info()], layer.providerType())
+        else:
+            self.versioning = versioningAbc([self.pg_conn_info(), uri.schema()], layer.providerType())
+            
+        
+        unresolved = self.versioning.unresolved_conflicts()
         if layer.providerType() == "spatialite":
-            unresolved = self.spversioning.unresolved_conflicts( [uri.database()] )
             for cflt in unresolved:
                 table = cflt+"_conflicts"
                 if not QgsMapLayerRegistry.instance().mapLayersByName(table):
@@ -752,8 +755,6 @@ class Plugin(QObject):
                             " key=\"OGC_FID\" table=\""+table+"\" "+
                             geom,table,'spatialite')
         else: #postgres
-            unresolved = self.pgversioning.unresolved_conflicts(
-                    [uri.connectionInfo(), uri.schema()] )
             for cflt in unresolved:
                 table = cflt+"_conflicts"
                 if not QgsMapLayerRegistry.instance().mapLayersByName(table):
@@ -790,22 +791,12 @@ class Plugin(QObject):
                 self.current_layers[0] )
         uri = QgsDataSourceURI(layer.source())
 
-        late_by = 0
+        late_by = 0       
+        late_by = self.versioning.late()
 
-        if layer.providerType() == "spatialite":
-            late_by = self.spversioning.late(
-                    [uri.database(), self.pg_conn_info()] )
-        else: # postgres
-            late_by = self.pgversioning.late(
-                    [self.pg_conn_info(), uri.schema()] )
         if late_by:
-            if layer.providerType() == "spatialite":
-                self.spversioning.update( [uri.database(), self.pg_conn_info()] )
-                rev = self.spversioning.revision( uri.database() )
-            else: # postgres
-                self.pgversioning.update( [uri.connectionInfo(), uri.schema()] )
-                rev = self.pgversioning.revision(
-                        [uri.connectionInfo(), uri.schema()] )
+            self.versioning.update()
+            rev = self.versioning.revision()
 
             # Force refresh of map
             if self.iface.mapCanvas().isCachingEnabled():
@@ -825,11 +816,7 @@ class Plugin(QObject):
                 "Working copy was late by "+str(late_by)+" revision(s).\n"
                 "Now up to date with remote revision "+str(rev-1)+".")
         else:
-            if layer.providerType() == "spatialite":
-                rev = self.spversioning.revision( uri.database() )
-            else: # postgres
-                rev = self.pgversioning.revision(
-                        [uri.connectionInfo(), uri.schema()] )
+            rev = self.versioning.revision()
             QMessageBox.information( self.iface.mainWindow(), "Info","Working "
             "copy already up to date with remote revision "+str(rev-1)+".")
 
@@ -933,8 +920,8 @@ class Plugin(QObject):
             os.remove(filename)
 
         print "checking out ", tables_for_conninfo, " from ",uri.connectionInfo()
-        self.spversioning.checkout( self.pg_conn_info(),
-                tables_for_conninfo, filename, user_selected_features )
+        self.versioning = versioningAbc([filename, self.pg_conn_info()], 'spatialite')
+        self.versioning.checkout(tables_for_conninfo, user_selected_features )
 
         # add layers from offline version
         grp_name = 'working copy'
@@ -1037,8 +1024,8 @@ class Plugin(QObject):
             "<b>lowercase</b> letters, underscore or digits.", duration=10)
             return
         print "checking out ", tables_for_conninfo, " from ", uri.connectionInfo()
-        self.pgversioning.checkout( self.pg_conn_info(),
-                tables_for_conninfo, working_copy_schema, user_selected_features )
+        self.versioning = versioningAbc([self.pg_conn_info(), working_copy_schema], 'postgres')
+        self.versioning.checkout(tables_for_conninfo, user_selected_features )
 
         # add layers from offline version
         grp_idx = self.iface.legendInterface().addGroup( working_copy_schema )
@@ -1067,12 +1054,7 @@ class Plugin(QObject):
         uri = QgsDataSourceURI(layer.source())
 
         late_by = 0
-        if layer.providerType() == "spatialite":
-            late_by = self.spversioning.late(
-                    [uri.database(), self.pg_conn_info()] )
-        else:#postgres
-            late_by = self.pgversioning.late(
-                    [self.pg_conn_info(), uri.schema()] )
+        late_by = self.versioning.late()
 
         if late_by:
             QMessageBox.warning(self.iface.mainWindow(), "Warning",
@@ -1115,15 +1097,8 @@ class Plugin(QObject):
 
         nb_of_updated_layer = 0
         rev = 0
-        if layer.providerType() == "spatialite":
-            nb_of_updated_layer = self.spversioning.commit( [uri.database(), self.pg_conn_info()], 
-                    commit_msg, commit_pg_user )
-            rev = self.spversioning.revision(uri.database())
-        else: # postgres
-            nb_of_updated_layer = self.pgversioning.commit(
-                    [uri.connectionInfo(), uri.schema()], commit_msg )
-            rev = self.pgversioning.revision(
-                    [uri.connectionInfo(), uri.schema()])
+        nb_of_updated_layer = self.versioning.commit( commit_msg, commit_pg_user )
+        rev = self.versioning.revision()
 
         if nb_of_updated_layer:
             #self.iface.messageBar().pushMessage("Info",

--- a/plugin.py
+++ b/plugin.py
@@ -737,9 +737,9 @@ class Plugin(QObject):
         uri = QgsDataSourceURI(layer.source())
 
         if layer.providerType() == 'spatialite':
-            self.versioning = versioning.versioningDb([uri.database(), self.pg_conn_info()], layer.providerType())
+            self.versioning = versioning.spatialite(uri.database(), self.pg_conn_info())
         else:
-            self.versioning = versioning.versioningDb([self.pg_conn_info(), uri.schema()], layer.providerType())
+            self.versioning = versioning.pgLocal(self.pg_conn_info(), uri.schema())
             
         
         unresolved = self.versioning.unresolved_conflicts()
@@ -918,7 +918,7 @@ class Plugin(QObject):
             os.remove(filename)
 
         print "checking out ", tables_for_conninfo, " from ",uri.connectionInfo()
-        self.versioning = versioning.versioningDb([filename, self.pg_conn_info()], 'spatialite')
+        self.versioning = versioning.spatialite(filename, self.pg_conn_info())
         self.versioning.checkout(tables_for_conninfo, user_selected_features )
 
         # add layers from offline version
@@ -1022,7 +1022,7 @@ class Plugin(QObject):
             "<b>lowercase</b> letters, underscore or digits.", duration=10)
             return
         print "checking out ", tables_for_conninfo, " from ", uri.connectionInfo()
-        self.versioning = versioning.versioningDb([self.pg_conn_info(), working_copy_schema], 'postgres')
+        self.versioning = versioning.pgLocal(self.pg_conn_info(), working_copy_schema)
         self.versioning.checkout(tables_for_conninfo, user_selected_features )
 
         # add layers from offline version

--- a/plugin.py
+++ b/plugin.py
@@ -790,7 +790,6 @@ class Plugin(QObject):
                 self.current_layers[0] )
         uri = QgsDataSourceURI(layer.source())
 
-        late_by = 0       
         late_by = self.versioning.late()
 
         if late_by:
@@ -1052,7 +1051,6 @@ class Plugin(QObject):
                 self.current_layers[0] )
         uri = QgsDataSourceURI(layer.source())
 
-        late_by = 0
         late_by = self.versioning.late()
 
         if late_by:

--- a/test/abbreviation_bug_test.py
+++ b/test/abbreviation_bug_test.py
@@ -19,7 +19,7 @@ def test(host, pguser):
     if os.path.isfile(sqlite_test_filename):
         os.remove(sqlite_test_filename)
 
-    spversioning = versioning.versioningDb([sqlite_test_filename, pg_conn_info], 'spatialite')
+    spversioning = versioning.spatialite(sqlite_test_filename, pg_conn_info)
     # create the test database
     os.system("dropdb --if-exists -h " + host + " -U "+pguser+" epanet_test_db")
     os.system("createdb -h " + host + " -U "+pguser+" epanet_test_db")

--- a/test/abbreviation_bug_test.py
+++ b/test/abbreviation_bug_test.py
@@ -5,7 +5,6 @@ sys.path.insert(0, '..')
 
 from versioningDB import versioning
 from pyspatialite import dbapi2
-from versioningDB.versioningAbc import versioningAbc
 import psycopg2
 import os
 import shutil
@@ -20,7 +19,7 @@ def test(host, pguser):
     if os.path.isfile(sqlite_test_filename):
         os.remove(sqlite_test_filename)
 
-    spversioning = versioningAbc([sqlite_test_filename, pg_conn_info], 'spatialite')
+    spversioning = versioning.versioningDb([sqlite_test_filename, pg_conn_info], 'spatialite')
     # create the test database
     os.system("dropdb --if-exists -h " + host + " -U "+pguser+" epanet_test_db")
     os.system("createdb -h " + host + " -U "+pguser+" epanet_test_db")

--- a/test/bug_in_branch_after_commit.py
+++ b/test/bug_in_branch_after_commit.py
@@ -5,7 +5,6 @@ sys.path.insert(0, '..')
 
 from versioningDB import versioning
 from pyspatialite import dbapi2
-from versioningDB.versioningAbc import versioningAbc
 import os
 import tempfile
 
@@ -27,7 +26,7 @@ def test(host, pguser):
     wc = tmp_dir+"/bug_in_branch_after_commit_wc.sqlite"
     if os.path.isfile(wc): os.remove(wc) 
     
-    spversioning = versioningAbc([wc, pg_conn_info], 'spatialite')
+    spversioning = versioning.versioningDb([wc, pg_conn_info], 'spatialite')
     spversioning.checkout(['epanet_trunk_rev_head.junctions', 'epanet_trunk_rev_head.pipes'])
 
     scur = versioning.Db( dbapi2.connect( wc ) )

--- a/test/bug_in_branch_after_commit.py
+++ b/test/bug_in_branch_after_commit.py
@@ -26,7 +26,7 @@ def test(host, pguser):
     wc = tmp_dir+"/bug_in_branch_after_commit_wc.sqlite"
     if os.path.isfile(wc): os.remove(wc) 
     
-    spversioning = versioning.versioningDb([wc, pg_conn_info], 'spatialite')
+    spversioning = versioning.spatialite(wc, pg_conn_info)
     spversioning.checkout(['epanet_trunk_rev_head.junctions', 'epanet_trunk_rev_head.pipes'])
 
     scur = versioning.Db( dbapi2.connect( wc ) )

--- a/test/bug_in_branch_after_commit.py
+++ b/test/bug_in_branch_after_commit.py
@@ -5,13 +5,12 @@ sys.path.insert(0, '..')
 
 from versioningDB import versioning
 from pyspatialite import dbapi2
-from versioningDB.spatialite import spVersioning
+from versioningDB.versioningAbc import versioningAbc
 import os
 import tempfile
 
 def test(host, pguser):
     pg_conn_info = "dbname=epanet_test_db host=" + host + " user=" + pguser
-    spversioning = spVersioning()
     test_data_dir = os.path.dirname(os.path.realpath(__file__))
     tmp_dir = tempfile.gettempdir()
 
@@ -27,7 +26,9 @@ def test(host, pguser):
     # try the update
     wc = tmp_dir+"/bug_in_branch_after_commit_wc.sqlite"
     if os.path.isfile(wc): os.remove(wc) 
-    spversioning.checkout(pg_conn_info, ['epanet_trunk_rev_head.junctions', 'epanet_trunk_rev_head.pipes'], wc)
+    
+    spversioning = versioningAbc([wc, pg_conn_info], 'spatialite')
+    spversioning.checkout(['epanet_trunk_rev_head.junctions', 'epanet_trunk_rev_head.pipes'])
 
     scur = versioning.Db( dbapi2.connect( wc ) )
 
@@ -35,7 +36,7 @@ def test(host, pguser):
     scur.execute("UPDATE pipes_view SET length = 1 WHERE OGC_FID = 1")
     scur.commit()
 
-    spversioning.commit([wc, pg_conn_info],'test' )
+    spversioning.commit('test')
 
     versioning.add_branch(pg_conn_info,"epanet","mybranch","add 'branch")
 

--- a/test/issue287_test.py
+++ b/test/issue287_test.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import sys
 sys.path.insert(0, '..')
 
-from versioningDB.versioningAbc import versioningAbc
+from versioningDB import versioning
 import os
 import shutil
 import tempfile
@@ -23,7 +23,7 @@ def test(host, pguser):
     # try the update
     sqlite_test_filename = os.path.join(tmp_dir, "issue287_wc.sqlite")
     shutil.copyfile(os.path.join(test_data_dir, "issue287_wc.sqlite"), sqlite_test_filename)
-    spversioning = versioningAbc([sqlite_test_filename, pg_conn_info], 'spatialite')
+    spversioning = versioning.versioningDb([sqlite_test_filename, pg_conn_info], 'spatialite')
     spversioning.update()
     spversioning.commit("test message")
 

--- a/test/issue287_test.py
+++ b/test/issue287_test.py
@@ -3,14 +3,13 @@ from __future__ import absolute_import
 import sys
 sys.path.insert(0, '..')
 
-from versioningDB.spatialite import spVersioning
+from versioningDB.versioningAbc import versioningAbc
 import os
 import shutil
 import tempfile
 
 def test(host, pguser):
     pg_conn_info = "dbname=epanet_test_db host=" + host + " user=" + pguser
-    spversioning = spVersioning()
     
     test_data_dir = os.path.dirname(os.path.realpath(__file__))
     tmp_dir = tempfile.gettempdir()
@@ -22,9 +21,11 @@ def test(host, pguser):
     os.system("psql -h " + host + " -U "+pguser+" epanet_test_db -f "+test_data_dir+"/issue287_pg_dump.sql")
 
     # try the update
-    shutil.copyfile(test_data_dir+"/issue287_wc.sqlite", tmp_dir+"/issue287_wc.sqlite")
-    spversioning.update([ tmp_dir+"/issue287_wc.sqlite", pg_conn_info] )
-    spversioning.commit([tmp_dir+"/issue287_wc.sqlite", pg_conn_info], "test message")
+    sqlite_test_filename = os.path.join(tmp_dir, "issue287_wc.sqlite")
+    shutil.copyfile(os.path.join(test_data_dir, "issue287_wc.sqlite"), sqlite_test_filename)
+    spversioning = versioningAbc([sqlite_test_filename, pg_conn_info], 'spatialite')
+    spversioning.update()
+    spversioning.commit("test message")
 
 if __name__ == "__main__":
     if len(sys.argv) != 3:

--- a/test/issue287_test.py
+++ b/test/issue287_test.py
@@ -23,7 +23,7 @@ def test(host, pguser):
     # try the update
     sqlite_test_filename = os.path.join(tmp_dir, "issue287_wc.sqlite")
     shutil.copyfile(os.path.join(test_data_dir, "issue287_wc.sqlite"), sqlite_test_filename)
-    spversioning = versioning.versioningDb([sqlite_test_filename, pg_conn_info], 'spatialite')
+    spversioning = versioning.spatialite(sqlite_test_filename, pg_conn_info)
     spversioning.update()
     spversioning.commit("test message")
 

--- a/test/issue357_test.py
+++ b/test/issue357_test.py
@@ -23,8 +23,8 @@ def test(host, pguser):
 
     # try the update
     wc = [os.path.join(tmp_dir, "issue357_wc0.sqlite"), os.path.join(tmp_dir, "issue357_wc1.sqlite")]
-    spversioning0 = versioning.versioningDb([wc[0], pg_conn_info], 'spatialite')
-    spversioning1 = versioning.versioningDb([wc[1], pg_conn_info], 'spatialite')
+    spversioning0 = versioning.spatialite(wc[0], pg_conn_info)
+    spversioning1 = versioning.spatialite(wc[1], pg_conn_info)
     for i, f in enumerate(wc):
         if os.path.isfile(f): os.remove(f)
         sp = spversioning0 if i == 0 else spversioning1

--- a/test/issue357_test.py
+++ b/test/issue357_test.py
@@ -5,7 +5,7 @@ sys.path.insert(0, '..')
 
 from pyspatialite import dbapi2
 from versioningDB import versioning
-from versioningDB.spatialite import spVersioning
+from versioningDB.versioningAbc import versioningAbc
 import psycopg2
 import os
 import shutil
@@ -13,7 +13,6 @@ import tempfile
 
 def test(host, pguser):
     pg_conn_info = "dbname=epanet_test_db host=" + host + " user=" + pguser
-    spversioning = spVersioning()
     test_data_dir = os.path.dirname(os.path.realpath(__file__))
     tmp_dir = tempfile.gettempdir()
 
@@ -24,10 +23,13 @@ def test(host, pguser):
     os.system("psql -h " + host + " -U "+pguser+" epanet_test_db -f "+test_data_dir+"/epanet_test_db.sql")
 
     # try the update
-    wc = [tmp_dir+"/issue357_wc0.sqlite", tmp_dir+"/issue357_wc1.sqlite"]
-    for f in wc:
-        if os.path.isfile(f): os.remove(f) 
-        spversioning.checkout(pg_conn_info, ['epanet_trunk_rev_head.junctions', 'epanet_trunk_rev_head.pipes'], f)
+    wc = [os.path.join(tmp_dir, "issue357_wc0.sqlite"), os.path.join(tmp_dir, "issue357_wc1.sqlite")]
+    spversioning0 = versioningAbc([wc[0], pg_conn_info], 'spatialite')
+    spversioning1 = versioningAbc([wc[1], pg_conn_info], 'spatialite')
+    for i, f in enumerate(wc):
+        if os.path.isfile(f): os.remove(f)
+        sp = spversioning0 if i == 0 else spversioning1
+        sp.checkout(['epanet_trunk_rev_head.junctions', 'epanet_trunk_rev_head.pipes'])
 
     scur = []
     for f in wc: scur.append(versioning.Db( dbapi2.connect( f ) ))
@@ -37,8 +39,8 @@ def test(host, pguser):
     scur[0].commit()
 
 
-    spversioning.commit( [wc[0], pg_conn_info], 'commit 1 wc0')
-    spversioning.update( [wc[1], pg_conn_info] )
+    spversioning0.commit( 'commit 1 wc0')
+    spversioning1.update(  )
 
     scur[0].execute("UPDATE pipes_view SET length = 1")
     scur[0].commit()
@@ -46,7 +48,7 @@ def test(host, pguser):
     scur[1].execute("UPDATE pipes_view SET length = 3")
     scur[1].commit()
 
-    spversioning.commit( [wc[0], pg_conn_info], "commit 2 wc0" )
+    spversioning0.commit( "commit 2 wc0" )
     scur[0].execute("SELECT OGC_FID,length,trunk_rev_begin,trunk_rev_end,trunk_parent,trunk_child FROM pipes")
     print '################'
     for r in scur[0].fetchall():
@@ -55,14 +57,14 @@ def test(host, pguser):
     scur[0].execute("UPDATE pipes_view SET length = 2")
     scur[0].execute("DELETE FROM pipes_view WHERE OGC_FID = 6")
     scur[0].commit()
-    spversioning.commit( [wc[0], pg_conn_info], "commit 3 wc0" )
+    spversioning0.commit( "commit 3 wc0" )
 
     scur[0].execute("SELECT OGC_FID,length,trunk_rev_begin,trunk_rev_end,trunk_parent,trunk_child FROM pipes")
     print '################'
     for r in scur[0].fetchall():
         print r
 
-    spversioning.update( [wc[1], pg_conn_info] )
+    spversioning1.update(  )
 
     scur[1].execute("SELECT OGC_FID,length,trunk_rev_begin,trunk_rev_end,trunk_parent,trunk_child FROM pipes_diff")
     print '################ diff'

--- a/test/issue357_test.py
+++ b/test/issue357_test.py
@@ -5,7 +5,6 @@ sys.path.insert(0, '..')
 
 from pyspatialite import dbapi2
 from versioningDB import versioning
-from versioningDB.versioningAbc import versioningAbc
 import psycopg2
 import os
 import shutil
@@ -24,8 +23,8 @@ def test(host, pguser):
 
     # try the update
     wc = [os.path.join(tmp_dir, "issue357_wc0.sqlite"), os.path.join(tmp_dir, "issue357_wc1.sqlite")]
-    spversioning0 = versioningAbc([wc[0], pg_conn_info], 'spatialite')
-    spversioning1 = versioningAbc([wc[1], pg_conn_info], 'spatialite')
+    spversioning0 = versioning.versioningDb([wc[0], pg_conn_info], 'spatialite')
+    spversioning1 = versioning.versioningDb([wc[1], pg_conn_info], 'spatialite')
     for i, f in enumerate(wc):
         if os.path.isfile(f): os.remove(f)
         sp = spversioning0 if i == 0 else spversioning1

--- a/test/issue358_test.py
+++ b/test/issue358_test.py
@@ -5,13 +5,12 @@ sys.path.insert(0, '..')
 
 from versioningDB import versioning
 from pyspatialite import dbapi2
-from versioningDB.spatialite import spVersioning
+from versioningDB.versioningAbc import versioningAbc
 import os
 import tempfile
 
 def test(host, pguser):
     pg_conn_info = "dbname=epanet_test_db host=" + host + " user=" + pguser
-    spversioning = spVersioning()
     test_data_dir = os.path.dirname(os.path.realpath(__file__))
     tmp_dir = tempfile.gettempdir()
 
@@ -24,7 +23,8 @@ def test(host, pguser):
     # try the update
     wc = tmp_dir+"/issue358_wc.sqlite"
     if os.path.isfile(wc): os.remove(wc) 
-    spversioning.checkout(pg_conn_info, ['epanet_trunk_rev_head.junctions', 'epanet_trunk_rev_head.pipes'], wc)
+    spversioning = versioningAbc([wc, pg_conn_info], 'spatialite')
+    spversioning.checkout(['epanet_trunk_rev_head.junctions', 'epanet_trunk_rev_head.pipes'])
 
     scur = versioning.Db( dbapi2.connect( wc ) )
 

--- a/test/issue358_test.py
+++ b/test/issue358_test.py
@@ -5,7 +5,6 @@ sys.path.insert(0, '..')
 
 from versioningDB import versioning
 from pyspatialite import dbapi2
-from versioningDB.versioningAbc import versioningAbc
 import os
 import tempfile
 
@@ -23,7 +22,7 @@ def test(host, pguser):
     # try the update
     wc = tmp_dir+"/issue358_wc.sqlite"
     if os.path.isfile(wc): os.remove(wc) 
-    spversioning = versioningAbc([wc, pg_conn_info], 'spatialite')
+    spversioning = versioning.versioningDb([wc, pg_conn_info], 'spatialite')
     spversioning.checkout(['epanet_trunk_rev_head.junctions', 'epanet_trunk_rev_head.pipes'])
 
     scur = versioning.Db( dbapi2.connect( wc ) )

--- a/test/issue358_test.py
+++ b/test/issue358_test.py
@@ -22,7 +22,7 @@ def test(host, pguser):
     # try the update
     wc = tmp_dir+"/issue358_wc.sqlite"
     if os.path.isfile(wc): os.remove(wc) 
-    spversioning = versioning.versioningDb([wc, pg_conn_info], 'spatialite')
+    spversioning = versioning.spatialite(wc, pg_conn_info)
     spversioning.checkout(['epanet_trunk_rev_head.junctions', 'epanet_trunk_rev_head.pipes'])
 
     scur = versioning.Db( dbapi2.connect( wc ) )

--- a/test/issue437_test.py
+++ b/test/issue437_test.py
@@ -5,7 +5,6 @@ sys.path.insert(0, '..')
 
 from versioningDB import versioning 
 from pyspatialite import dbapi2
-from versioningDB.versioningAbc import versioningAbc
 import psycopg2
 import os
 import shutil
@@ -25,8 +24,8 @@ def test(host, pguser):
 
     # try the update
     wc = [os.path.join(tmp_dir,"issue437_wc0.sqlite"), os.path.join(tmp_dir,"issue437_wc1.sqlite")]
-    spversioning0 = versioningAbc([wc[0], pg_conn_info], 'spatialite')
-    spversioning1 = versioningAbc([wc[1], pg_conn_info], 'spatialite')
+    spversioning0 = versioning.versioningDb([wc[0], pg_conn_info], 'spatialite')
+    spversioning1 = versioning.versioningDb([wc[1], pg_conn_info], 'spatialite')
     for i, f in enumerate(wc):
         if os.path.isfile(f): os.remove(f) 
         sp = spversioning0 if i == 0 else spversioning1

--- a/test/issue437_test.py
+++ b/test/issue437_test.py
@@ -24,8 +24,8 @@ def test(host, pguser):
 
     # try the update
     wc = [os.path.join(tmp_dir,"issue437_wc0.sqlite"), os.path.join(tmp_dir,"issue437_wc1.sqlite")]
-    spversioning0 = versioning.versioningDb([wc[0], pg_conn_info], 'spatialite')
-    spversioning1 = versioning.versioningDb([wc[1], pg_conn_info], 'spatialite')
+    spversioning0 = versioning.spatialite(wc[0], pg_conn_info)
+    spversioning1 = versioning.spatialite(wc[1], pg_conn_info)
     for i, f in enumerate(wc):
         if os.path.isfile(f): os.remove(f) 
         sp = spversioning0 if i == 0 else spversioning1

--- a/test/issue485_test.py
+++ b/test/issue485_test.py
@@ -120,7 +120,7 @@ def test(host, pguser):
 
     wc = tmp_dir+'/wc_multiple_geometry_test.sqlite'
     if os.path.isfile(wc): os.remove(wc)
-    spversioning = versioning.versioningDb([wc, pg_conn_info], 'spatialite')
+    spversioning = versioning.spatialite(wc, pg_conn_info)
     spversioning.checkout( ['epanet_trunk_rev_head.pipes','epanet_trunk_rev_head.junctions'] )
 
 

--- a/test/issue485_test.py
+++ b/test/issue485_test.py
@@ -5,7 +5,6 @@ sys.path.insert(0, '..')
 
 from versioningDB import versioning 
 from pyspatialite import dbapi2
-from versioningDB.versioningAbc import versioningAbc
 import psycopg2
 import os
 import shutil
@@ -121,7 +120,7 @@ def test(host, pguser):
 
     wc = tmp_dir+'/wc_multiple_geometry_test.sqlite'
     if os.path.isfile(wc): os.remove(wc)
-    spversioning = versioningAbc([wc, pg_conn_info], 'spatialite')
+    spversioning = versioning.versioningDb([wc, pg_conn_info], 'spatialite')
     spversioning.checkout( ['epanet_trunk_rev_head.pipes','epanet_trunk_rev_head.junctions'] )
 
 

--- a/test/issue486_test.py
+++ b/test/issue486_test.py
@@ -4,7 +4,6 @@ sys.path.insert(0, '..')
 
 from versioningDB import versioning
 from pyspatialite import dbapi2
-from versioningDB.versioningAbc import versioningAbc
 import psycopg2
 import os
 import shutil
@@ -84,7 +83,7 @@ def test(host, pguser):
 
     wc = tmp_dir+'/wc_multiple_geometry_test.sqlite'
     if os.path.isfile(wc): os.remove(wc) 
-    spversioning = versioningAbc([wc, pg_conn_info], 'spatialite')
+    spversioning = versioning.versioningDb([wc, pg_conn_info], 'spatialite')
     spversioning.checkout( ['epanet_trunk_rev_head.pipes','epanet_trunk_rev_head.junctions'] )
 
 

--- a/test/issue486_test.py
+++ b/test/issue486_test.py
@@ -4,7 +4,7 @@ sys.path.insert(0, '..')
 
 from versioningDB import versioning
 from pyspatialite import dbapi2
-from versioningDB.spatialite import spVersioning
+from versioningDB.versioningAbc import versioningAbc
 import psycopg2
 import os
 import shutil
@@ -12,7 +12,6 @@ import tempfile
 
 def test(host, pguser):
     pg_conn_info = "dbname=epanet_test_db host=" + host + " user=" + pguser
-    spversioning = spVersioning()
     
     test_data_dir = os.path.dirname(os.path.realpath(__file__))
     tmp_dir = tempfile.gettempdir()
@@ -85,7 +84,8 @@ def test(host, pguser):
 
     wc = tmp_dir+'/wc_multiple_geometry_test.sqlite'
     if os.path.isfile(wc): os.remove(wc) 
-    spversioning.checkout( pg_conn_info, ['epanet_trunk_rev_head.pipes','epanet_trunk_rev_head.junctions'], wc )
+    spversioning = versioningAbc([wc, pg_conn_info], 'spatialite')
+    spversioning.checkout( ['epanet_trunk_rev_head.pipes','epanet_trunk_rev_head.junctions'] )
 
 
     scur = versioning.Db( dbapi2.connect(wc) )
@@ -95,7 +95,7 @@ def test(host, pguser):
     print "--------------"
     for res in scur.fetchall(): print res
     scur.close()
-    spversioning.commit( [wc, pg_conn_info], 'moved a junction' )
+    spversioning.commit( 'moved a junction' )
 
     pcur.execute("SELECT ST_AsText(geometry), ST_AsText(geometry_schematic), printmap FROM epanet_trunk_rev_head.junctions ORDER BY hid DESC")
     res = pcur.fetchall()

--- a/test/issue486_test.py
+++ b/test/issue486_test.py
@@ -83,7 +83,7 @@ def test(host, pguser):
 
     wc = tmp_dir+'/wc_multiple_geometry_test.sqlite'
     if os.path.isfile(wc): os.remove(wc) 
-    spversioning = versioning.versioningDb([wc, pg_conn_info], 'spatialite')
+    spversioning = versioning.spatialite(wc, pg_conn_info)
     spversioning.checkout( ['epanet_trunk_rev_head.pipes','epanet_trunk_rev_head.junctions'] )
 
 

--- a/test/multiple_geometry_test.py
+++ b/test/multiple_geometry_test.py
@@ -4,7 +4,6 @@ import sys
 sys.path.insert(0, '..')
 
 from versioningDB import versioning 
-from versioningDB.versioningAbc import versioningAbc
 from pyspatialite import dbapi2
 import psycopg2
 import os
@@ -121,7 +120,7 @@ def test(host, pguser):
 
 
     wc = os.path.join(tmp_dir, 'wc_multiple_geometry_test.sqlite')
-    spversioning = versioningAbc([wc, pg_conn_info], 'spatialite')
+    spversioning = versioning.versioningDb([wc, pg_conn_info], 'spatialite')
     if os.path.isfile(wc): os.remove(wc)
     spversioning.checkout( ['epanet_trunk_rev_head.pipes','epanet_trunk_rev_head.junctions'] )
 

--- a/test/multiple_geometry_test.py
+++ b/test/multiple_geometry_test.py
@@ -120,7 +120,7 @@ def test(host, pguser):
 
 
     wc = os.path.join(tmp_dir, 'wc_multiple_geometry_test.sqlite')
-    spversioning = versioning.versioningDb([wc, pg_conn_info], 'spatialite')
+    spversioning = versioning.spatialite(wc, pg_conn_info)
     if os.path.isfile(wc): os.remove(wc)
     spversioning.checkout( ['epanet_trunk_rev_head.pipes','epanet_trunk_rev_head.junctions'] )
 

--- a/test/multiple_geometry_test.py
+++ b/test/multiple_geometry_test.py
@@ -4,7 +4,7 @@ import sys
 sys.path.insert(0, '..')
 
 from versioningDB import versioning 
-from versioningDB.spatialite import spVersioning
+from versioningDB.versioningAbc import versioningAbc
 from pyspatialite import dbapi2
 import psycopg2
 import os
@@ -119,11 +119,11 @@ def test(host, pguser):
     assert( res[0][0] == 'POINT(0 0)' )
     assert( res[1][1] == 'POLYGON((0 0,2 0,2 2,0 2,0 0))' )
 
-    spversioning = spVersioning()
 
-    wc = tmp_dir+'/wc_multiple_geometry_test.sqlite'
+    wc = os.path.join(tmp_dir, 'wc_multiple_geometry_test.sqlite')
+    spversioning = versioningAbc([wc, pg_conn_info], 'spatialite')
     if os.path.isfile(wc): os.remove(wc)
-    spversioning.checkout( pg_conn_info, ['epanet_trunk_rev_head.pipes','epanet_trunk_rev_head.junctions'], wc )
+    spversioning.checkout( ['epanet_trunk_rev_head.pipes','epanet_trunk_rev_head.junctions'] )
 
 
     scur = versioning.Db( dbapi2.connect(wc) )
@@ -131,7 +131,7 @@ def test(host, pguser):
     scur.commit()
     scur.close()
 
-    spversioning.commit( [wc, pg_conn_info], 'a commit msg' )
+    spversioning.commit( 'a commit msg' )
 
     pcur.execute("SELECT ST_AsText(geometry), ST_AsText(geometry_schematic) FROM epanet_trunk_rev_head.junctions")
     res = pcur.fetchall()

--- a/test/partial_checkout_test.py
+++ b/test/partial_checkout_test.py
@@ -3,7 +3,6 @@ import sys
 sys.path.insert(0, '..')
 
 from versioningDB import versioning
-from versioningDB.versioningAbc import versioningAbc
 
 from pyspatialite import dbapi2
 import psycopg2
@@ -21,7 +20,7 @@ def test(host, pguser):
     if os.path.isfile(sqlite_test_filename):
         os.remove(sqlite_test_filename)
         
-    spversioning = versioningAbc([sqlite_test_filename, pg_conn_info], 'spatialite')
+    spversioning = versioning.versioningDb([sqlite_test_filename, pg_conn_info], 'spatialite')
 
     # create the test database
     os.system("dropdb --if-exists -h " + host + " -U "+pguser+" epanet_test_db")
@@ -59,7 +58,7 @@ def test(host, pguser):
     assert len(scur.fetchall()) ==  3
 
     # postgres working copy
-    pgversioning = versioningAbc([pg_conn_info, 'my_working_copy'], 'postgres')
+    pgversioning = versioning.versioningDb([pg_conn_info, 'my_working_copy'], 'postgres')
     pgversioning.checkout(["epanet_trunk_rev_head.junctions","epanet_trunk_rev_head.pipes"], [[1, 2, 3], []])
 
     pcon = psycopg2.connect(pg_conn_info)

--- a/test/partial_checkout_test.py
+++ b/test/partial_checkout_test.py
@@ -3,8 +3,7 @@ import sys
 sys.path.insert(0, '..')
 
 from versioningDB import versioning
-from versioningDB.postgresqlLocal import pgVersioning
-from versioningDB.spatialite import spVersioning
+from versioningDB.versioningAbc import versioningAbc
 
 from pyspatialite import dbapi2
 import psycopg2
@@ -15,15 +14,14 @@ import tempfile
 def test(host, pguser):
     pg_conn_info = "dbname=epanet_test_db host=" + host + " user=" + pguser
     
-    pgversioning = pgVersioning()
-    spversioning = spVersioning()
-    
     tmp_dir = tempfile.gettempdir()
     test_data_dir = os.path.dirname(os.path.realpath(__file__))
 
-    sqlite_test_filename = tmp_dir+"/partial_checkout_test.sqlite"
+    sqlite_test_filename = os.path.join(tmp_dir, "partial_checkout_test.sqlite")
     if os.path.isfile(sqlite_test_filename):
         os.remove(sqlite_test_filename)
+        
+    spversioning = versioningAbc([sqlite_test_filename, pg_conn_info], 'spatialite')
 
     # create the test database
     os.system("dropdb --if-exists -h " + host + " -U "+pguser+" epanet_test_db")
@@ -52,7 +50,7 @@ def test(host, pguser):
     versioning.historize(pg_conn_info, 'epanet')
 
     # spatialite working copy
-    spversioning.checkout(pg_conn_info,["epanet_trunk_rev_head.junctions","epanet_trunk_rev_head.pipes"], sqlite_test_filename, [[1, 2, 3], []])
+    spversioning.checkout(["epanet_trunk_rev_head.junctions","epanet_trunk_rev_head.pipes"], [[1, 2, 3], []])
     assert( os.path.isfile(sqlite_test_filename) and "sqlite file must exist at this point" )
 
     scon = dbapi2.connect(sqlite_test_filename)
@@ -61,7 +59,8 @@ def test(host, pguser):
     assert len(scur.fetchall()) ==  3
 
     # postgres working copy
-    pgversioning.checkout(pg_conn_info,["epanet_trunk_rev_head.junctions","epanet_trunk_rev_head.pipes"], 'my_working_copy', [[1, 2, 3], []])
+    pgversioning = versioningAbc([pg_conn_info, 'my_working_copy'], 'postgres')
+    pgversioning.checkout(["epanet_trunk_rev_head.junctions","epanet_trunk_rev_head.pipes"], [[1, 2, 3], []])
 
     pcon = psycopg2.connect(pg_conn_info)
     pcur = pcon.cursor()

--- a/test/partial_checkout_test.py
+++ b/test/partial_checkout_test.py
@@ -20,7 +20,7 @@ def test(host, pguser):
     if os.path.isfile(sqlite_test_filename):
         os.remove(sqlite_test_filename)
         
-    spversioning = versioning.versioningDb([sqlite_test_filename, pg_conn_info], 'spatialite')
+    spversioning = versioning.spatialite(sqlite_test_filename, pg_conn_info)
 
     # create the test database
     os.system("dropdb --if-exists -h " + host + " -U "+pguser+" epanet_test_db")
@@ -58,7 +58,7 @@ def test(host, pguser):
     assert len(scur.fetchall()) ==  3
 
     # postgres working copy
-    pgversioning = versioning.versioningDb([pg_conn_info, 'my_working_copy'], 'postgres')
+    pgversioning = versioning.pgLocal(pg_conn_info, 'my_working_copy')
     pgversioning.checkout(["epanet_trunk_rev_head.junctions","epanet_trunk_rev_head.pipes"], [[1, 2, 3], []])
 
     pcon = psycopg2.connect(pg_conn_info)

--- a/test/posgres_working_copy_bug_in_conflict_test.py
+++ b/test/posgres_working_copy_bug_in_conflict_test.py
@@ -37,8 +37,8 @@ def test(host, pguser):
         pcur = versioning.Db(psycopg2.connect(pg_conn_info))
 
         tables = ['epanet_trunk_rev_head.junctions', 'epanet_trunk_rev_head.pipes']
-        pgversioning1 = versioning.versioningDb([pg_conn_info, 'wc1'], 'postgres')
-        pgversioning2 = versioning.versioningDb([pg_conn_info, 'wc2'], 'postgres')
+        pgversioning1 = versioning.pgLocal(pg_conn_info, 'wc1')
+        pgversioning2 = versioning.pgLocal(pg_conn_info, 'wc2')
         pgversioning1.checkout(tables)
         pgversioning2.checkout(tables)
         print "checkout done"

--- a/test/posgres_working_copy_bug_in_conflict_test.py
+++ b/test/posgres_working_copy_bug_in_conflict_test.py
@@ -3,8 +3,7 @@ from __future__ import absolute_import
 import sys
 sys.path.insert(0, '..')
 
-from versioningDB import versioning 
-from versioningDB.versioningAbc import versioningAbc
+from versioningDB import versioning
 import psycopg2
 import os
 import shutil
@@ -38,8 +37,8 @@ def test(host, pguser):
         pcur = versioning.Db(psycopg2.connect(pg_conn_info))
 
         tables = ['epanet_trunk_rev_head.junctions', 'epanet_trunk_rev_head.pipes']
-        pgversioning1 = versioningAbc([pg_conn_info, 'wc1'], 'postgres')
-        pgversioning2 = versioningAbc([pg_conn_info, 'wc2'], 'postgres')
+        pgversioning1 = versioning.versioningDb([pg_conn_info, 'wc1'], 'postgres')
+        pgversioning2 = versioning.versioningDb([pg_conn_info, 'wc2'], 'postgres')
         pgversioning1.checkout(tables)
         pgversioning2.checkout(tables)
         print "checkout done"

--- a/test/posgres_working_copy_bug_in_view_test.py
+++ b/test/posgres_working_copy_bug_in_view_test.py
@@ -34,7 +34,7 @@ def test(host, pguser):
     os.system("psql -h " + host + " -U "+pguser+" epanet_test_db -f "+test_data_dir+"/epanet_test_db.sql")
 
     # chechout
-    pgversioning = versioning.versioningDb([pg_conn_info, 'epanet_working_copy'], 'postgres')
+    pgversioning = versioning.pgLocal(pg_conn_info, 'epanet_working_copy')
     pgversioning.checkout(['epanet_trunk_rev_head.junctions','epanet_trunk_rev_head.pipes'])
 
     pcur = versioning.Db(psycopg2.connect(pg_conn_info))

--- a/test/posgres_working_copy_bug_in_view_test.py
+++ b/test/posgres_working_copy_bug_in_view_test.py
@@ -4,7 +4,7 @@ import sys
 sys.path.insert(0, '..')
 
 from versioningDB import versioning 
-from versioningDB.postgresqlLocal import pgVersioning
+from versioningDB.versioningAbc import versioningAbc
 import psycopg2
 import os
 import shutil
@@ -27,7 +27,6 @@ def test(host, pguser):
     pg_conn_info = "dbname=epanet_test_db host=" + host + " user=" + pguser
     test_data_dir = os.path.dirname(os.path.realpath(__file__))
 
-    pgversioning = pgVersioning()
     # create the test database
 
     os.system("dropdb --if-exists -h " + host + " -U "+pguser+" epanet_test_db")
@@ -36,7 +35,8 @@ def test(host, pguser):
     os.system("psql -h " + host + " -U "+pguser+" epanet_test_db -f "+test_data_dir+"/epanet_test_db.sql")
 
     # chechout
-    pgversioning.checkout(pg_conn_info,['epanet_trunk_rev_head.junctions','epanet_trunk_rev_head.pipes'], "epanet_working_copy")
+    pgversioning = versioningAbc([pg_conn_info, 'epanet_working_copy'], 'postgres')
+    pgversioning.checkout(['epanet_trunk_rev_head.junctions','epanet_trunk_rev_head.pipes'])
 
     pcur = versioning.Db(psycopg2.connect(pg_conn_info))
 

--- a/test/posgres_working_copy_bug_in_view_test.py
+++ b/test/posgres_working_copy_bug_in_view_test.py
@@ -3,8 +3,7 @@ from __future__ import absolute_import
 import sys
 sys.path.insert(0, '..')
 
-from versioningDB import versioning 
-from versioningDB.versioningAbc import versioningAbc
+from versioningDB import versioning
 import psycopg2
 import os
 import shutil
@@ -35,7 +34,7 @@ def test(host, pguser):
     os.system("psql -h " + host + " -U "+pguser+" epanet_test_db -f "+test_data_dir+"/epanet_test_db.sql")
 
     # chechout
-    pgversioning = versioningAbc([pg_conn_info, 'epanet_working_copy'], 'postgres')
+    pgversioning = versioning.versioningDb([pg_conn_info, 'epanet_working_copy'], 'postgres')
     pgversioning.checkout(['epanet_trunk_rev_head.junctions','epanet_trunk_rev_head.pipes'])
 
     pcur = versioning.Db(psycopg2.connect(pg_conn_info))

--- a/test/posgres_working_copy_test.py
+++ b/test/posgres_working_copy_test.py
@@ -4,7 +4,7 @@ import sys
 sys.path.insert(0, '..')
 
 from versioningDB import versioning 
-from versioningDB.postgresqlLocal import pgVersioning
+from versioningDB.versioningAbc import versioningAbc
 import psycopg2
 import os
 import shutil
@@ -27,7 +27,6 @@ def test(host, pguser):
     pg_conn_info = "dbname=epanet_test_db host=" + host + " user=" + pguser
     test_data_dir = os.path.dirname(os.path.realpath(__file__))
 
-    pgversioning = pgVersioning()
     # create the test database
 
     os.system("dropdb --if-exists -h " + host + " -U "+pguser+" epanet_test_db")
@@ -38,9 +37,11 @@ def test(host, pguser):
     # chechout
     #tables = ['epanet_trunk_rev_head.junctions','epanet_trunk_rev_head.pipes']
     tables = ['epanet_trunk_rev_head.junctions', 'epanet_trunk_rev_head.pipes']
-    pgversioning.checkout(pg_conn_info,tables, "epanet_working_copy")
+    pgversioning1 = versioningAbc([pg_conn_info, 'epanet_working_copy'], 'postgres')
+    pgversioning2 = versioningAbc([pg_conn_info, 'epanet_working_copy_cflt'], 'postgres')
+    pgversioning1.checkout(tables)
 
-    pgversioning.checkout(pg_conn_info,tables, "epanet_working_copy_cflt")
+    pgversioning2.checkout(tables)
 
     pcur = versioning.Db(psycopg2.connect(pg_conn_info))
 
@@ -71,7 +72,7 @@ def test(host, pguser):
     prtTab(pcur, 'epanet_working_copy.pipes_diff')
     pcur.commit()
 
-    pgversioning.commit([pg_conn_info, "epanet_working_copy"],"test commit msg")
+    pgversioning1.commit("test commit msg")
     prtTab(pcur, 'epanet.pipes')
 
     pcur.execute("SELECT trunk_rev_end FROM epanet.pipes WHERE pid = 1")
@@ -100,7 +101,7 @@ def test(host, pguser):
     pcur.execute("INSERT INTO epanet_working_copy_cflt.pipes_view(id, start_node, end_node, geom) VALUES ('3','1','2',ST_GeometryFromText('LINESTRING(1 -1,0 1)',2154))")
     prtTab(pcur, 'epanet_working_copy_cflt.pipes_diff')
     pcur.commit()
-    pgversioning.update( [pg_conn_info, "epanet_working_copy_cflt"] )
+    pgversioning2.update(  )
     prtTab(pcur, 'epanet_working_copy_cflt.pipes_diff')
     prtTab(pcur, 'epanet_working_copy_cflt.pipes_update_diff')
 
@@ -120,7 +121,7 @@ def test(host, pguser):
     prtTab(pcur, 'epanet_working_copy_cflt.pipes_conflicts')
     pcur.commit()
 
-    pgversioning.commit([pg_conn_info, "epanet_working_copy_cflt"],"second test commit msg")
+    pgversioning2.commit("second test commit msg")
 
 
     pcur.execute("SELECT * FROM epanet_working_copy_cflt.initial_revision")
@@ -134,7 +135,7 @@ def test(host, pguser):
     prtTab(pcur, 'epanet_working_copy_cflt.pipes_diff')
     pcur.commit()
 
-    pgversioning.commit([pg_conn_info, "epanet_working_copy_cflt"],"third test commit msg")
+    pgversioning2.commit("third test commit msg")
 
 
     prtTab(pcur, 'epanet_working_copy_cflt.pipes_diff')

--- a/test/posgres_working_copy_test.py
+++ b/test/posgres_working_copy_test.py
@@ -36,8 +36,8 @@ def test(host, pguser):
     # chechout
     #tables = ['epanet_trunk_rev_head.junctions','epanet_trunk_rev_head.pipes']
     tables = ['epanet_trunk_rev_head.junctions', 'epanet_trunk_rev_head.pipes']
-    pgversioning1 = versioning.versioningDb([pg_conn_info, 'epanet_working_copy'], 'postgres')
-    pgversioning2 = versioning.versioningDb([pg_conn_info, 'epanet_working_copy_cflt'], 'postgres')
+    pgversioning1 = versioning.pgLocal(pg_conn_info, 'epanet_working_copy')
+    pgversioning2 = versioning.pgLocal(pg_conn_info, 'epanet_working_copy_cflt')
     pgversioning1.checkout(tables)
 
     pgversioning2.checkout(tables)

--- a/test/posgres_working_copy_test.py
+++ b/test/posgres_working_copy_test.py
@@ -4,7 +4,6 @@ import sys
 sys.path.insert(0, '..')
 
 from versioningDB import versioning 
-from versioningDB.versioningAbc import versioningAbc
 import psycopg2
 import os
 import shutil
@@ -37,8 +36,8 @@ def test(host, pguser):
     # chechout
     #tables = ['epanet_trunk_rev_head.junctions','epanet_trunk_rev_head.pipes']
     tables = ['epanet_trunk_rev_head.junctions', 'epanet_trunk_rev_head.pipes']
-    pgversioning1 = versioningAbc([pg_conn_info, 'epanet_working_copy'], 'postgres')
-    pgversioning2 = versioningAbc([pg_conn_info, 'epanet_working_copy_cflt'], 'postgres')
+    pgversioning1 = versioning.versioningDb([pg_conn_info, 'epanet_working_copy'], 'postgres')
+    pgversioning2 = versioning.versioningDb([pg_conn_info, 'epanet_working_copy_cflt'], 'postgres')
     pgversioning1.checkout(tables)
 
     pgversioning2.checkout(tables)

--- a/test/versioning_base_test.py
+++ b/test/versioning_base_test.py
@@ -34,11 +34,11 @@ def test(host, pguser):
     os.system("psql -h " + host + " -U "+pguser+" epanet_test_db -c 'CREATE EXTENSION postgis'")
     os.system("psql -h " + host + " -U "+pguser+" epanet_test_db -f "+test_data_dir+"/epanet_test_db.sql")
 
-    spversioning1 = versioning.versioningDb([sqlite_test_filename1, pg_conn_info], 'spatialite')
-    spversioning2 = versioning.versioningDb([sqlite_test_filename2, pg_conn_info], 'spatialite')
-    spversioning3 = versioning.versioningDb([sqlite_test_filename3, pg_conn_info], 'spatialite')
-    spversioning4 = versioning.versioningDb([sqlite_test_filename4, pg_conn_info], 'spatialite')
-    spversioning5 = versioning.versioningDb([sqlite_test_filename5, pg_conn_info], 'spatialite')
+    spversioning1 = versioning.spatialite(sqlite_test_filename1, pg_conn_info)
+    spversioning2 = versioning.spatialite(sqlite_test_filename2, pg_conn_info)
+    spversioning3 = versioning.spatialite(sqlite_test_filename3, pg_conn_info)
+    spversioning4 = versioning.spatialite(sqlite_test_filename4, pg_conn_info)
+    spversioning5 = versioning.spatialite(sqlite_test_filename5, pg_conn_info)
     # chechout two tables
 
     try:

--- a/test/versioning_base_test.py
+++ b/test/versioning_base_test.py
@@ -3,8 +3,9 @@ from __future__ import absolute_import
 import sys
 sys.path.insert(0, '..')
 
-from versioningDB.versioningAbc import versioningAbc
 from versioningDB.versioning import diff_rev_view_str
+
+from versioningDB import versioning 
 from pyspatialite import dbapi2
 import psycopg2
 import os
@@ -33,11 +34,11 @@ def test(host, pguser):
     os.system("psql -h " + host + " -U "+pguser+" epanet_test_db -c 'CREATE EXTENSION postgis'")
     os.system("psql -h " + host + " -U "+pguser+" epanet_test_db -f "+test_data_dir+"/epanet_test_db.sql")
 
-    spversioning1 = versioningAbc([sqlite_test_filename1, pg_conn_info], 'spatialite')
-    spversioning2 = versioningAbc([sqlite_test_filename2, pg_conn_info], 'spatialite')
-    spversioning3 = versioningAbc([sqlite_test_filename3, pg_conn_info], 'spatialite')
-    spversioning4 = versioningAbc([sqlite_test_filename4, pg_conn_info], 'spatialite')
-    spversioning5 = versioningAbc([sqlite_test_filename5, pg_conn_info], 'spatialite')
+    spversioning1 = versioning.versioningDb([sqlite_test_filename1, pg_conn_info], 'spatialite')
+    spversioning2 = versioning.versioningDb([sqlite_test_filename2, pg_conn_info], 'spatialite')
+    spversioning3 = versioning.versioningDb([sqlite_test_filename3, pg_conn_info], 'spatialite')
+    spversioning4 = versioning.versioningDb([sqlite_test_filename4, pg_conn_info], 'spatialite')
+    spversioning5 = versioning.versioningDb([sqlite_test_filename5, pg_conn_info], 'spatialite')
     # chechout two tables
 
     try:

--- a/versioningDB/postgresqlLocal.py
+++ b/versioningDB/postgresqlLocal.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import absolute_import
-from .versioningAbc import AbstractVersioning
 from .utils import *
 import psycopg2
 
@@ -9,7 +8,7 @@ from itertools import izip_longest
 
 DEBUG=False
 
-class pgVersioning(AbstractVersioning):    
+class pgVersioning(object):    
     
     def revision(self, connection ):
         (pg_conn_info, working_copy_schema) = connection
@@ -299,8 +298,8 @@ class pgVersioning(AbstractVersioning):
     # we need the initial_revision table all the same
     # for each table we need a diff and a view and triggers
     
-    def checkout(self, pg_conn_info, pg_table_names, working_source, selected_feature_lists = []):
-        working_copy_schema = working_source 
+    def checkout(self, connection, pg_table_names, selected_feature_lists = []):
+        (pg_conn_info, working_copy_schema) = connection
         """create postgres working copy from versioned database tables
         pg_table_names must be complete schema.table names
         the schema name must end with _branch_rev_head

--- a/versioningDB/spatialite.py
+++ b/versioningDB/spatialite.py
@@ -1,18 +1,18 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import absolute_import
-from .versioningAbc import AbstractVersioning
 from .utils import *
 from itertools import izip_longest
 
 import os
 DEBUG=False
 
-class spVersioning(AbstractVersioning):
+class spVersioning(object):
     
     def revision(self, connection ):
+        sqlite_filename = connection[0]
         """returns the revision the working copy was created from plus one"""
-        scur = Db(dbapi2.connect(connection))
+        scur = Db(dbapi2.connect(sqlite_filename))
         scur.execute("SELECT rev "+ "FROM initial_revision")
         rev = 0
         for [res] in scur.fetchall():
@@ -321,8 +321,8 @@ class spVersioning(AbstractVersioning):
         scur.close()
         
     
-    def checkout(self, pg_conn_info, pg_table_names, working_source, selected_feature_lists = []):
-        sqlite_filename = working_source
+    def checkout(self, connection, pg_table_names, selected_feature_lists = []):
+        (sqlite_filename, pg_conn_info) = connection
         """create working copy from versioned database tables
         pg_table_names must be complete schema.table names
         the schema name must end with _branch_rev_head
@@ -550,9 +550,7 @@ class spVersioning(AbstractVersioning):
         scur.close()
         return found
     
-    # commit(self, sqlite_filename, commit_msg, pg_conn_info, commit_pg_user = ''):
     def commit(self, connection, commit_msg, commit_user = ''):
-        (sqlite_filename, pg_conn_info) = connection
         """merge modifications into database
         returns the number of updated layers"""
         # get the target revision from the spatialite db
@@ -561,7 +559,7 @@ class spVersioning(AbstractVersioning):
         # detect conflicts
         # merge changes and update target_revision
         # delete diff
-    
+        (sqlite_filename, pg_conn_info) = connection
         unresolved = self.unresolved_conflicts([sqlite_filename])
         if unresolved:
             raise RuntimeError("There are unresolved conflicts in "

--- a/versioningDB/versioning.py
+++ b/versioningDB/versioning.py
@@ -11,8 +11,9 @@ from pyspatialite import dbapi2
 import psycopg2
 import platform
 from . import utils
+from .versioningAbc import versioningAbc
 
-
+versioningDb = versioningAbc
 Db = utils.Db
 os_info = utils.os_info
 pg_pk = utils.pg_pk

--- a/versioningDB/versioning.py
+++ b/versioningDB/versioning.py
@@ -14,6 +14,12 @@ from . import utils
 from .versioningAbc import versioningAbc
 
 versioningDb = versioningAbc
+def spatialite(sqlite_filename, pg_conn_info):
+    return versioningDb([sqlite_filename, pg_conn_info], 'spatialite')
+
+def pgLocal(pg_conn_info, schema):
+    return versioningDb([pg_conn_info, schema], 'postgres')
+
 Db = utils.Db
 os_info = utils.os_info
 pg_pk = utils.pg_pk

--- a/versioningDB/versioningAbc.py
+++ b/versioningDB/versioningAbc.py
@@ -1,35 +1,43 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import absolute_import
-import abc
 
-class AbstractVersioning(object):
-    __metaclass__ = abc.ABCMeta
+from .postgresqlLocal import pgVersioning
+from .spatialite import spVersioning
+
+TYPE = ('postgres', 'spatialite')
+
+class versioningAbc(object):
     
-#    def __init__(self):
-#        pass
+    def __init__(self, connection, typebase):
+        assert(isinstance(connection, list) and 
+               len(connection) == 2 and
+               typebase in TYPE)
         
-    @abc.abstractmethod
-    def revision( connection ):
-        return
+        self.typebase = typebase
+        # spatialite : [sqlite_filename, pg_conn_info]
+        # postgres : [pg_conn_info, working_copy_schema]
+        self.connection = connection
+        if self.typebase == 'spatialite':
+            self.ver = spVersioning()
+        else:
+            self.ver = pgVersioning()
+            
+    def revision(self):
+        return self.ver.revision(self.connection)
     
-    @abc.abstractmethod
-    def late( connection ):
-        return
+    def late(self ):
+        return self.ver.late(self.connection)
     
-    @abc.abstractmethod
-    def update(connection):
-        return
+    def update(self):
+        self.ver.update(self.connection)
     
-    @abc.abstractmethod
-    def checkout(pg_conn_info, pg_table_names, working_source, selected_feature_lists = []):
-        return
+    def checkout(self, pg_table_names, selected_feature_lists = []):
+        self.ver.checkout(self.connection, pg_table_names, selected_feature_lists = [])
     
-    @abc.abstractmethod
-    def unresolved_conflicts(connection):
-        return
+    def unresolved_conflicts(self):
+        return self.ver.unresolved_conflicts(self.connection)
     
-    @abc.abstractmethod
-    def commit(connection, commit_msg, commit_user = ''):
-        return
+    def commit(self, commit_msg, commit_user = ''):
+        return self.ver.commit(self.connection, commit_msg, commit_user)
         

--- a/versioningDB/versioningAbc.py
+++ b/versioningDB/versioningAbc.py
@@ -33,7 +33,7 @@ class versioningAbc(object):
         self.ver.update(self.connection)
     
     def checkout(self, pg_table_names, selected_feature_lists = []):
-        self.ver.checkout(self.connection, pg_table_names, selected_feature_lists = [])
+        self.ver.checkout(self.connection, pg_table_names, selected_feature_lists)
     
     def unresolved_conflicts(self):
         return self.ver.unresolved_conflicts(self.connection)


### PR DESCRIPTION
This PR finalizes the refactoring by making the `VersioningAbc` class the only one to be used.

As for `versioningDb.utils`, an alias is present in `versioning.py` so `versioning` should be the only file to be included.