### PR TITLE
Add workaround for UUID type

### DIFF
--- a/test/epanet_test_db_uuid.sql
+++ b/test/epanet_test_db_uuid.sql
@@ -1,0 +1,79 @@
+﻿CREATE EXTENSION IF NOT EXISTS postgis;
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+CREATE SCHEMA epanet;
+
+CREATE TABLE epanet.junctions (
+    gid uuid DEFAULT uuid_generate_v4 (),
+    jid serial PRIMARY KEY,
+    id varchar,
+    elevation float, 
+    base_demand_flow float, 
+    demand_pattern_id varchar, 
+    geom geometry('POINT',2154)
+);
+
+INSERT INTO epanet.junctions
+    (id, elevation, geom)
+    VALUES
+    ('0',0,ST_GeometryFromText('POINT(1 0)',2154));
+
+INSERT INTO epanet.junctions
+    (id, elevation, geom)
+    VALUES
+    ('1',1,ST_GeometryFromText('POINT(0 1)',2154));
+
+CREATE TABLE epanet.pipes (
+    gid uuid DEFAULT uuid_generate_v4 (),
+    pid serial PRIMARY KEY,
+    id varchar,
+    start_node varchar,
+    end_node varchar,
+    length float,
+    diameter float,
+    roughness float,
+    minor_loss_coefficient float,
+    status varchar,
+    geom geometry('LINESTRING',2154)
+);
+
+INSERT INTO epanet.pipes
+    (id, start_node, end_node, length, diameter, geom) 
+    VALUES
+    ('0','0','1',1,2,ST_GeometryFromText('LINESTRING(1 0,0 1)',2154));
+
+CREATE TABLE epanet.revisions(
+    rev serial PRIMARY KEY,
+    commit_msg varchar,
+    branch varchar DEFAULT 'trunk',
+    date timestamp DEFAULT current_timestamp,
+    author varchar);
+INSERT INTO epanet.revisions VALUES (1,'initial commit','trunk');
+
+ALTER TABLE epanet.junctions
+ADD COLUMN trunk_rev_begin integer REFERENCES epanet.revisions(rev), 
+ADD COLUMN trunk_rev_end integer REFERENCES epanet.revisions(rev), 
+ADD COLUMN trunk_parent integer REFERENCES epanet.junctions(jid),
+ADD COLUMN trunk_child  integer REFERENCES epanet.junctions(jid);
+
+ALTER TABLE epanet.pipes
+ADD COLUMN trunk_rev_begin integer REFERENCES epanet.revisions(rev), 
+ADD COLUMN trunk_rev_end integer REFERENCES epanet.revisions(rev), 
+ADD COLUMN trunk_parent integer REFERENCES epanet.pipes(pid),
+ADD COLUMN trunk_child  integer REFERENCES epanet.pipes(pid);
+
+UPDATE epanet.junctions SET trunk_rev_begin = 1;
+
+UPDATE epanet.pipes SET trunk_rev_begin = 1;
+
+CREATE SCHEMA epanet_trunk_rev_head;
+
+CREATE VIEW epanet_trunk_rev_head.junctions
+AS SELECT gid, jid, id, elevation, base_demand_flow, demand_pattern_id, geom
+   FROM epanet.junctions
+   WHERE trunk_rev_end IS NULL AND trunk_rev_begin IS NOT NULL;
+  
+CREATE VIEW epanet_trunk_rev_head.pipes
+AS SELECT  pid, id, start_node, end_node, length, diameter, roughness, minor_loss_coefficient, status, geom
+   FROM epanet.pipes
+   WHERE trunk_rev_end IS NULL AND trunk_rev_begin IS NOT NULL;
+

--- a/test/postgres_distant_uuid_test.py
+++ b/test/postgres_distant_uuid_test.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python2
+from __future__ import absolute_import
+import sys
+sys.path.insert(0, '..')
+
+from versioningDB import versioning 
+from pyspatialite import dbapi2
+import psycopg2
+import os
+import tempfile
+
+
+def prtTab( cur, tab ):
+    print ("--- ",tab," ---")
+    cur.execute("SELECT ogc_fid, trunk_rev_begin, trunk_rev_end, trunk_parent, trunk_child, length FROM "+tab)
+    for r in cur.fetchall():
+        t = []
+        for i in r: t.append(str(i))
+        print ('\t| '.join(t))
+
+def prtHid( cur, tab ):
+    print ("--- ",tab," ---")
+    cur.execute("SELECT ogc_fid FROM "+tab)
+    for [r] in cur.fetchall(): print (r)
+
+def test(host, pguser):
+    pg_conn_info = "dbname=epanet_test_db host=" + host + " user=" + pguser
+    pg_conn_info_cpy = "dbname=epanet_test_copy_db host=" + host + " user=" + pguser
+    test_data_dir = os.path.dirname(os.path.realpath(__file__))
+    tmp_dir = tempfile.gettempdir()
+
+    # create the test database
+
+    os.system("dropdb --if-exists -h " + host + " -U "+pguser+" epanet_test_db")
+    os.system("dropdb --if-exists -h " + host + " -U "+pguser+" epanet_test_copy_db")
+    os.system("createdb -h " + host + " -U "+pguser+" epanet_test_db")
+    os.system("createdb -h " + host + " -U "+pguser+" epanet_test_copy_db")
+    os.system("psql -h " + host + " -U "+pguser+" epanet_test_db -c 'CREATE EXTENSION postgis'")
+    os.system("psql -h " + host + " -U "+pguser+" epanet_test_copy_db -c 'CREATE EXTENSION postgis'")
+    os.system("psql -h " + host + " -U "+pguser+" epanet_test_db -f "+test_data_dir+"/epanet_test_db_uuid.sql")
+
+    # chechout
+    #tables = ['epanet_trunk_rev_head.junctions','epanet_trunk_rev_head.pipes']
+    tables = ['epanet_trunk_rev_head.junctions', 'epanet_trunk_rev_head.pipes']
+    pgversioning = versioning.pgLocal(pg_conn_info, 'epanet_trunk_rev_head', pg_conn_info_cpy)
+    pgversioning.checkout(tables)
+    
+    
+    pcurcpy = versioning.Db(psycopg2.connect(pg_conn_info_cpy))
+    pcur = versioning.Db(psycopg2.connect(pg_conn_info))
+
+
+    pcurcpy.execute("INSERT INTO epanet_trunk_rev_head.pipes_view(id, start_node, end_node, wkb_geometry) VALUES ('2','1','2',ST_GeometryFromText('LINESTRING(1 1,0 1)',2154))")
+    pcurcpy.execute("INSERT INTO epanet_trunk_rev_head.pipes_view(id, start_node, end_node, wkb_geometry) VALUES ('3','1','2',ST_GeometryFromText('LINESTRING(1 -1,0 1)',2154))")
+    pcurcpy.commit()
+
+
+    prtHid(pcurcpy, 'epanet_trunk_rev_head.pipes_view')
+
+    pcurcpy.execute("SELECT * FROM epanet_trunk_rev_head.pipes_view")
+    assert( len(pcurcpy.fetchall()) == 3 )
+    pcur.execute("SELECT * FROM epanet.pipes")
+    assert( len(pcur.fetchall()) == 1 )
+    pgversioning.commit('INSERT')
+    pcur.execute("SELECT * FROM epanet.pipes")
+    assert( len(pcur.fetchall()) == 3 )
+
+    pcurcpy.execute("UPDATE epanet_trunk_rev_head.pipes_view SET start_node = '2' WHERE id = '0'")
+    pcurcpy.commit()
+    pcurcpy.execute("SELECT * FROM epanet_trunk_rev_head.pipes_view")
+    assert( len(pcurcpy.fetchall())  == 3 )
+    pcur.execute("SELECT * FROM epanet.pipes")
+    assert( len(pcur.fetchall())== 3 )
+    pgversioning.commit('UPDATE')
+    pcur.execute("SELECT * FROM epanet.pipes")
+    assert( len(pcur.fetchall()) == 4 )
+   
+    pcurcpy.close()
+    pcur.close()
+    
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("Usage: python2 postgres_distant_uuid_test.py host pguser")
+    else:
+        test(*sys.argv[1:])

--- a/versioningDB/postgresqlLocal.py
+++ b/versioningDB/postgresqlLocal.py
@@ -843,7 +843,7 @@ class pgVersioningLocal(object):
                 
             pkey = pg_pk( pcur, table_schema, table )
             pcur.execute("""
-                SELECT column_name
+                SELECT column_name, data_type
                 FROM information_schema.columns
                 WHERE table_schema = '{table_schema}'
                 AND table_name = '{table}'
@@ -852,9 +852,13 @@ class pgVersioningLocal(object):
             cols = ""
             coli = ""
             allcols = pcur.fetchall()
-            for [col] in allcols:
+            for col, dtype in allcols:
                 if col not in history_columns:
-                    cols = quote_ident(col)+", "+cols
+                    # Workaround for uuid type
+                    if dtype == 'uuid':
+                        cols = 'uuid('+quote_ident(col)+')'+", "+cols
+                    else:
+                        cols = quote_ident(col)+", "+cols
                     coli = quote_ident(col)+", "+coli
                 else:
                     coli = quote_ident(col)+", "+coli


### PR DESCRIPTION
When checking out a schema to a distant base, uuid columns are transformed into varchar in sqlite (which acts as an intermediary). Importing via a commit is a problem.

`column "gid" is of type uuid but expression is of type character varying`

To remedy this, I add a bypass by casting the uuid column.